### PR TITLE
Ensure zero-allocation List functions; fix 2^32-length bugs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,7 +113,6 @@ jobs:
       - uses: ./.github/actions/setup
       - run: npm test
 
-      # Requires mops >= 2.17.0 for the `-- <moc flags>` passthrough
       - name: Tests under legacy persistence
         run: npx ic-mops test List.allocation -- --legacy-persistence
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,6 +113,12 @@ jobs:
       - uses: ./.github/actions/setup
       - run: npm test
 
+      # Rewrite the [moc] args line in place
+      - name: Tests under legacy persistence
+        run: | 
+          perl -pi -e 's/^args = .*/args = ["--legacy-persistence"]/' mops.toml
+          npx ic-mops test List.allocation
+
   bench:
     needs: check-motoko-changes
     if: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,11 +113,9 @@ jobs:
       - uses: ./.github/actions/setup
       - run: npm test
 
-      # Rewrite the [moc] args line in place
+      # Requires mops >= 2.17.0 for the `-- <moc flags>` passthrough
       - name: Tests under legacy persistence
-        run: | 
-          perl -pi -e 's/^args = .*/args = ["--legacy-persistence"]/' mops.toml
-          npx ic-mops test List.allocation
+        run: npx ic-mops test List.allocation -- --legacy-persistence
 
   bench:
     needs: check-motoko-changes

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,7 @@
 ## Next
+* Enforce the maximum `List` size of 2^32: `add` (and every other growth path) now traps with "List capacity of 2^32 elements exceeded" instead of silently creating elements that `get` denies. The out-of-bounds trap message of `List.at`/`put` changed as a side effect of the Nat64 conversion.
+* Fix `List` functions at the maximum size 2^32: `size` returned a wrapped value, `binarySearch` returned insertion index 0 instead of 2^32, and `lastIndexOf`/`prevIndexOf`, `truncate` and `addRepeat` trapped on size-valued arguments equal to 2^32. All internal index arithmetic (`locate`, `size`, `indexByBlockElement` and the inlined copies in `at`/`get`/`put`) is now Nat64-based, which also makes `at`/`get`/`put` 42/38/42 instructions cheaper per call.
+* Make `List.get`, `find`, `equal` and `compare` allocation-free (`get` also under legacy persistence), and add a wasi-mode regression test asserting zero allocation for all allocation-free `List` functions.
 * Fix `Queue` and `pure/Queue` for certain sequences of push + peek (#513).
 * Fix: correct List range/slice/get bounds handling (#512).
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 ## Next
-* Fix: correct List range/slice/get bounds handling (#512).
 * Fix `Queue` and `pure/Queue` for certain sequences of push + peek (#513).
+* Fix: correct List range/slice/get bounds handling (#512).
 
 ## 2.6.0
 * Add `Base64.decode : Text -> ?Blob`, the inverse of `Base64.encode` (RFC 4648 standard alphabet) (#507).

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,5 @@
 ## Next
-* Enforce the maximum `List` size of 2^32: `add` (and every other growth path) now traps with "List capacity of 2^32 elements exceeded" instead of silently creating elements that `get` denies. The out-of-bounds trap message of `List.at`/`put` changed as a side effect of the Nat64 conversion.
-* Fix `List` functions at the maximum size 2^32: `size` returned a wrapped value, `binarySearch` returned insertion index 0 instead of 2^32, and `lastIndexOf`/`prevIndexOf`, `truncate` and `addRepeat` trapped on size-valued arguments equal to 2^32. All internal index arithmetic (`locate`, `size`, `indexByBlockElement` and the inlined copies in `at`/`get`/`put`) is now Nat64-based, which also makes `at`/`get`/`put` 42/38/42 instructions cheaper per call.
-* Make `List.get`, `find`, `equal` and `compare` allocation-free (`get` also under legacy persistence), and add a wasi-mode regression test asserting zero allocation for all allocation-free `List` functions.
+* Remove unnecessary allocations in `List` functions. Fix bugs that occur for the exact maximum List size of `2^32` (#515). 
 * Fix `Queue` and `pure/Queue` for certain sequences of push + peek (#513).
 * Fix: correct List range/slice/get bounds handling (#512).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@dfinity/pic": "^0.13.1",
         "execa": "^4.1.0",
         "fast-glob": "^3.3.2",
-        "ic-mops": "^2.15.2",
+        "ic-mops": "2.17.0",
         "mo-dev": "^0.13.0",
         "npm-run-all": "^4.1.5",
         "prettier": "2",
@@ -4655,9 +4655,9 @@
       }
     },
     "node_modules/ic-mops": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/ic-mops/-/ic-mops-2.15.2.tgz",
-      "integrity": "sha512-45LZlI2aGAwFR1htinBZhaH6ATEHdXRMkOWqeArqwDwOxsdQTCZqlRoVLlDtkQhuPhPMQKK5HByqHgagUyQoig==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/ic-mops/-/ic-mops-2.17.0.tgz",
+      "integrity": "sha512-WUfodx+55Vmlb1e0a1tMG7tCNkApxliEwTZ5ra2hYvzleEltqBhcltQnL1iLlUvs1CLZVPC8ODNV3HmLZlgK5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@dfinity/pic": "^0.13.1",
     "execa": "^4.1.0",
     "fast-glob": "^3.3.2",
-    "ic-mops": "^2.15.2",
+    "ic-mops": "2.17.0",
     "mo-dev": "^0.13.0",
     "npm-run-all": "^4.1.5",
     "prettier": "2",

--- a/src/List.mo
+++ b/src/List.mo
@@ -2,6 +2,18 @@
 /// `List` provides O(1) access time and O(sqrt(n)) memory overhead. In contrast, `pure/List` is a purely functional linked list.
 /// Can be declared `stable` for orthogonal persistence.
 ///
+/// Performance note: on a 64-bit build (enhanced orthogonal persistence, the
+/// compiler default) all index and size arithmetic in this module operates on
+/// unboxed values over the entire supported size range (up to 2^32 elements),
+/// so there are no boxing-related performance cliffs or hidden allocations.
+/// On a 32-bit build (deprecated legacy persistence) `Nat` values >= 2^30 are
+/// boxed, so an operation receiving such an index, or internally computing
+/// such a size, would take slower bignum code paths and allocate a few dozen
+/// bytes per call. This is theoretical only: a 32-bit heap is limited to
+/// 4 GB and a list occupies at least 4 bytes per element, so a list can
+/// never actually grow to 2^30 elements there, and indices >= 2^30 can only
+/// occur as out-of-range arguments.
+///
 /// This implementation is adapted with permission from the `vector` Mops package created by Research AG.
 ///
 /// Copyright: 2023 MR Research AG

--- a/src/List.mo
+++ b/src/List.mo
@@ -15,7 +15,6 @@
 import PureList "pure/List";
 import Prim "mo:⛔";
 import Nat32 "Nat32";
-import Nat64 "Nat64";
 import Array "Array";
 import Nat "Nat";
 import Option "Option";
@@ -1101,7 +1100,7 @@ module {
   ///
   /// Space: `O(1)`
   public func get<T>(self : List<T>, index : Nat) : ?T {
-    if (Nat64.fromIntWrap(index) >> 32 != 0) return null;
+    if (Prim.shiftRight(index, 32) != 0) return null;
     // inlined version of locate
     let (a, b) = do {
       let i = Nat32.fromIntWrap(index);

--- a/src/List.mo
+++ b/src/List.mo
@@ -1104,7 +1104,7 @@ module {
     if (Nat64.fromIntWrap(index) >> 32 != 0) return null;
     // inlined version of locate
     let (a, b) = do {
-      let i = Nat.toNat32(index);
+      let i = Nat32.fromIntWrap(index);
       let lz = Nat32.bitcountLeadingZero(i);
       let lz2 = lz >> 1;
       if (lz & 1 == 0) {

--- a/src/List.mo
+++ b/src/List.mo
@@ -195,7 +195,7 @@ module {
   /// @deprecated M0235
   public func fromPure<T>(pure : PureList.List<T>) : List<T> {
     var p = pure;
-    var list = empty<T>();
+    let list = empty<T>();
     loop {
       switch (p) {
         case (?(x, xs)) {
@@ -319,7 +319,7 @@ module {
     if (elementIndex != 0) {
       let block = newBlocks[blockIndex];
       var i = elementIndex;
-      var to = block.size();
+      let to = block.size();
       while (i < to) {
         block[i] := null;
         i += 1
@@ -447,7 +447,7 @@ module {
   ///
   /// Space: O(number of elements in list)
   public func join<T>(self : Types.Iter<List<T>>) : List<T> {
-    var result = empty<T>();
+    let result = empty<T>();
     for (list in self) {
       reserve(result, size(list));
       forEach<T>(list, func item = addUnsafe(result, item))

--- a/src/List.mo
+++ b/src/List.mo
@@ -15,6 +15,7 @@
 import PureList "pure/List";
 import Prim "mo:⛔";
 import Nat32 "Nat32";
+import Nat64 "Nat64";
 import Array "Array";
 import Nat "Nat";
 import Option "Option";
@@ -888,9 +889,9 @@ module {
     // due to the design of List (blockIndex, elementIndex) pair points
     // exactly to the place where size-th element should be added
     // so, it's the inlined version of indexByBlockElement
-    let d = Nat.toNat32(self.blockIndex);
-    let lz = Nat32.bitcountLeadingZero(d / 3);
-    Nat32.toNat((d -% (1 <>> lz)) <>> lz +% Nat.toNat32(self.elementIndex))
+    let d = Nat.toNat64(self.blockIndex);
+    let lz = Nat64.bitcountLeadingZero(d / 3);
+    Nat64.toNat((d -% (1 <>> lz)) <>> lz +% Nat.toNat64(self.elementIndex))
   };
 
   func dataBlockSize(blockIndex : Nat) : Nat {

--- a/src/List.mo
+++ b/src/List.mo
@@ -1135,10 +1135,15 @@ module {
   ///
   /// Space: `O(1)`
   public func get<T>(self : List<T>, index : Nat) : ?T {
-    if (Prim.shiftRight(index, 32) != 0) return null;
+    // The guard only rejects index >= 2^64, where the wrap conversion
+    // below would alias a small index. Indices in [2^32, 2^64) fall
+    // through to the physical bounds checks: they yield a data block
+    // index >= 2^17, past any possible index block (the List capacity
+    // is 2^32), so `a < blocks.size()` fails and null is returned.
+    if (Prim.shiftRight(index, 64) != 0) return null;
     // inlined version of locate
     let (a, b) = do {
-      // the guard above ensures index < 2^32, so the wrap cannot trigger
+      // the guard above ensures index < 2^64, so the wrap cannot trigger
       let i = Nat64.fromIntWrap(index);
       let lz = Nat64.bitcountLeadingZero(i);
       let lz2 = lz >> 1;

--- a/src/List.mo
+++ b/src/List.mo
@@ -1464,7 +1464,10 @@ module {
   ///
   /// *Runtime and space assumes that `predicate` runs in O(1) time and space.
   public func find<T>(self : List<T>, predicate : T -> Bool) : ?T {
-    Option.map<Nat, T>(findIndex<T>(self, predicate), func(i) = at(self, i))
+    switch (findIndex<T>(self, predicate)) {
+      case (?i) ?at(self, i);
+      case null null
+    }
   };
 
   /// Finds the index of the first element in `list` for which `predicate` is true.

--- a/src/List.mo
+++ b/src/List.mo
@@ -1388,6 +1388,8 @@ module {
 
   /// Returns the index of the next occurence of `element` in the `list` starting from the `from` index (inclusive).
   ///
+  /// Traps if `fromInclusive >= size(list)`.
+  ///
   /// ```motoko include=import
   /// import Char "mo:core/Char";
   /// let list = List.fromArray(['c', 'o', 'f', 'f', 'e', 'e']);
@@ -1454,6 +1456,9 @@ module {
   );
 
   /// Returns the index of the previous occurence of `element` in the `list` starting from the `from` index (exclusive).
+  ///
+  /// Traps if `fromExclusive > size(list)`. Note that `fromExclusive = size(list)`
+  /// is valid and starts the search from the end of the list.
   ///
   /// ```motoko include=import
   /// import Char "mo:core/Char";

--- a/src/List.mo
+++ b/src/List.mo
@@ -2827,13 +2827,17 @@ module {
 
       var j = 0;
       while (j < sz) {
-        switch (db1[j], db2[j]) {
-          case (?x, ?y) switch (compare(x, y)) {
-            case (#less) return #less;
-            case (#greater) return #greater;
-            case _ {}
+        // nested switches only to avoid allocating a tuple for a pair switch
+        switch (db1[j]) {
+          case (?x) switch (db2[j]) {
+            case (?y) switch (compare(x, y)) {
+              case (#less) return #less;
+              case (#greater) return #greater;
+              case _ {}
+            };
+            case null break l
           };
-          case (_, _) break l
+          case null break l
         };
         j += 1
       };

--- a/src/List.mo
+++ b/src/List.mo
@@ -1112,8 +1112,10 @@ module {
         (Nat32.toNat(((i << lz2) >> 15) ^ (0x18000 >> lz2)), Nat32.toNat(i & (0x7FFF >> lz2)))
       }
     };
-    if (a < self.blockIndex or self.elementIndex != 0 and a == self.blockIndex) {
-      self.blocks[a][b]
+    let blocks = self.blocks;
+    if (a < blocks.size()) {
+      let db = blocks[a];
+      if (b < db.size()) db[b] else null
     } else null
   };
 

--- a/src/List.mo
+++ b/src/List.mo
@@ -1050,13 +1050,23 @@ module {
 
   func locate(index : Nat) : (Nat, Nat) {
     // see comments in tests
-    let i = Nat.toNat32(index);
-    let lz = Nat32.bitcountLeadingZero(i);
+    //
+    // Based on Nat64 arithmetic: the halves of the index are 32 bits wide
+    // instead of 16, hence all constants and shift amounts are doubled
+    // compared to the Nat32-based version. The branch parities are
+    // unchanged because 64 - 32 is even.
+    // Unlike the Nat32-based version this also accepts size-valued
+    // arguments, which reach 2^32 for a completely full list (from
+    // prevIndexOf, truncate, repeat/tabulate/addRepeat): locate(2^32)
+    // returns the normalized one-past-the-end position (131_072, 0),
+    // consistent with locate at every smaller data-block boundary.
+    let i = index.toNat64();
+    let lz = Nat64.bitcountLeadingZero(i);
     let lz2 = lz >> 1;
     if (lz & 1 == 0) {
-      (Nat32.toNat(((i << lz2) >> 16) ^ (0x10000 >> lz2)), Nat32.toNat(i & (0xFFFF >> lz2)))
+      ((((i << lz2) >> 32) ^ (0x1_0000_0000 >> lz2)).toNat(), (i & (0xFFFF_FFFF >> lz2)).toNat())
     } else {
-      (Nat32.toNat(((i << lz2) >> 15) ^ (0x18000 >> lz2)), Nat32.toNat(i & (0x7FFF >> lz2)))
+      ((((i << lz2) >> 31) ^ (0x1_8000_0000 >> lz2)).toNat(), (i & (0x7FFF_FFFF >> lz2)).toNat())
     }
   };
 

--- a/src/List.mo
+++ b/src/List.mo
@@ -1076,17 +1076,16 @@ module {
     return element
   };
 
+  // Returns the (blockIndex, elementIndex) position of the element with
+  // the given index. For example, locate(2^32) = (131_072, 0).
+  // Also often used with a size-valued argument, in which case the next
+  // next insertion position is returned (see prevIndexOf, truncate,
+  // repeat/tabulate/addRepeat).
   func locate(index : Nat) : (Nat, Nat) {
     // For the derivation of the bit arithmetic see locate_readable64
     // and locate_optimal64 in test/List.test.mo; the latter is a
     // verbatim copy of this function and tests its arithmetic across
     // the full supported range.
-    //
-    // Also accepts size-valued arguments, one beyond the largest index
-    // in a List (from prevIndexOf, truncate, repeat/tabulate/addRepeat):
-    // e.g. locate(2^32) returns the normalized one-past-the-end position
-    // (131_072, 0), consistent with locate at every smaller data-block
-    // boundary.
     let i = index.toNat64();
     let lz = Nat64.bitcountLeadingZero(i);
     let lz2 = lz >> 1;
@@ -1116,9 +1115,8 @@ module {
     //     case (?element) element;
     //     case (null) Prim.trap "";
     //   };
-    // Nat64-based like locate; for index >= size the block lookup or the
-    // null slot check below traps as required (the message just differs
-    // from the Nat32 version's).
+    // for index >= size the block lookup or the null slot check
+    // below traps as required.
     let i = index.toNat64();
     let lz = Nat64.bitcountLeadingZero(i);
     let lz2 = lz >> 1;
@@ -1150,9 +1148,8 @@ module {
   ///
   /// Space: `O(1)`
   public func get<T>(self : List<T>, index : Nat) : ?T {
-    // The guard only rejects index >= 2^64, where the wrap conversion
-    // below would alias a small index. Any index >= size falls through
-    // to the physical checks below: a block index beyond blocks.size()
+    // The guard only rejects index >= 2^64. Any index in `[size, 2^64)` falls
+    // through to the physical checks below: a block index beyond blocks.size()
     // or a null slot, so null is returned.
     if (Prim.shiftRight(index, 64) != 0) return null;
     // inlined version of locate
@@ -1187,9 +1184,9 @@ module {
   ///
   /// Runtime: `O(1)`
   public func put<T>(self : List<T>, index : Nat, value : T) {
-    // Nat64-based like locate; for index >= size the block lookup or the
-    // null slot check below traps as required (the message just differs
-    // from the Nat32 version's).
+    // inlined version of locate.
+    // for index >= size the block lookup or the null slot check
+    // below traps as required.
     let i = index.toNat64();
     let lz = Nat64.bitcountLeadingZero(i);
     let lz2 = lz >> 1;

--- a/src/List.mo
+++ b/src/List.mo
@@ -851,7 +851,7 @@ module {
   };
 
   func indexByBlockElement<T>(blockIndex : Nat, elementIndex : Nat) : Nat {
-    let d = Nat.toNat32(blockIndex);
+    let d = blockIndex.toNat64();
 
     // We call all data blocks of the same capacity an "epoch". We number the epochs 0,1,2,...
     // A data block is in epoch e iff the data block has capacity 2 ** e.
@@ -859,8 +859,8 @@ module {
     // Super block s falls in epoch ceil(s/2).
 
     // epoch of last data block
-    // e = 32 - lz
-    let lz = Nat32.bitcountLeadingZero(d / 3);
+    // e = 64 - lz
+    let lz = Nat64.bitcountLeadingZero(d / 3);
 
     // capacity of all prior epochs combined
     // capacity_before_e = 2 * 4 ** (e - 1) - 1
@@ -871,9 +871,18 @@ module {
     // then size = d * 2 ** e + i - c
     // where c = blocks_before_e * 2 ** e - capacity_before_e
 
-    // there can be overflows, but the result is without overflows, so use addWrap and subWrap
-    // we don't erase bits by >>, so to use <>> is ok
-    Nat32.toNat((d -% (1 <>> lz)) <>> lz +% Nat.toNat32(elementIndex))
+    // The formula is based on Nat64 arithmetic (one epoch further up than
+    // the Nat32-based one would be), like in size(): no intermediate result
+    // overflows for blockIndex <= 2^17. In particular the one-past-the-end
+    // insertion position (131_071, 65_536) of a completely full list maps
+    // correctly to 2^32, which would overflow Nat32.
+    //
+    // Intermediate values may exceed 2^64; that is harmless because every
+    // operation used (-%, +%, <>>) is a bijection mod 2^64, so the final
+    // value is exact whenever the true result fits in 64 bits. A plain >>
+    // would erase the shifted-out bits and break this argument, which is
+    // why the rotation <>> is used.
+    ((d -% (1 <>> lz)) <>> lz +% elementIndex.toNat64()).toNat()
   };
 
   /// Returns the current number of elements in the list.

--- a/src/List.mo
+++ b/src/List.mo
@@ -2,10 +2,13 @@
 /// `List` provides O(1) access time and O(sqrt(n)) memory overhead. In contrast, `pure/List` is a purely functional linked list.
 /// Can be declared `stable` for orthogonal persistence.
 ///
+/// The List size is in practice limited only by available memory. The
+/// theoretical limit is 2^61 elements.
+///
 /// Performance note: on a 64-bit build (enhanced orthogonal persistence, the
 /// compiler default) all index and size arithmetic in this module operates on
-/// unboxed values over the entire supported size range (up to 2^32 elements),
-/// so there are no boxing-related performance cliffs or hidden allocations.
+/// unboxed values, so there are no boxing-related performance cliffs or
+/// hidden allocations.
 /// On a 32-bit build (deprecated legacy persistence) `Nat` values >= 2^30 are
 /// boxed, so an operation receiving such an index, or internally computing
 /// such a size, would take slower bignum code paths and allocate a few dozen
@@ -921,18 +924,21 @@ module {
     Nat32.toNat(1 <>> Nat32.bitcountLeadingZero(Nat.toNat32(blockIndex) / 3))
   };
 
+  // The Nat32 arithmetic below bounds the List size to exactly 2^61
+  // elements: it produces valid index block lengths up to and including
+  // the top rung 3 * 2^30, whose index block fills exactly when the List
+  // reaches size 2^61 (insertion state (3 * 2^30, 0)). One step further
+  // the round-up 4 << 30 wraps to 0, so at exactly size 2^61 add traps
+  // with "Array index out of bounds" (growing into the wrapped
+  // zero-length index block) -- the effect of a capacity guard, with a
+  // less descriptive message. All other operations keep working at
+  // size 2^61, including removeLast, whose shrink path dodges the wrap
+  // with the early return in shrinkIndexBlockIfNeeded. Constructor and
+  // addRepeat targets in (2^61, 2^62) hit the same wrap; targets
+  // >= 2^62 trap in the Nat.toNat32 conversions at the call sites. The
+  // bound is theoretical: 2^61 elements need at least 16 EiB of data
+  // blocks, orders of magnitude beyond any real memory.
   func newIndexBlockLength(blockIndex : Nat32) : Nat {
-    // The maximum List capacity is 2^32 elements, stored in data blocks
-    // 1..131_071; asking to accommodate a block index beyond that means
-    // the capacity would be exceeded. This is the single chokepoint that
-    // all index block growth goes through (add, repeat, tabulate,
-    // addRepeat, ...), and it only executes when the index block actually
-    // grows, so this guard costs one comparison on a path that runs
-    // O(log capacity) times over a list's lifetime — never on ordinary
-    // adds. Without the guard the element would be written successfully
-    // but get() would deny its existence (guarded at index < 2^32),
-    // silently breaking the API's consistency.
-    if (blockIndex > 131_071) Prim.trap "List capacity of 2^32 elements exceeded";
     if (blockIndex <= 1) 2 else {
       let s = 30 - Nat32.bitcountLeadingZero(blockIndex);
       Nat32.toNat(((blockIndex >> s) +% 1) << s)
@@ -953,12 +959,12 @@ module {
 
   func shrinkIndexBlockIfNeeded<T>(list : List<T>) {
     let blockIndex = Nat.toNat32(list.blockIndex);
-    // At the completely full list the insertion state sits one past the
-    // maximal data block. No shrink is possible there (the index block is
-    // at its exactly-full ladder length, and newIndexBlockLength of the
-    // one-past index could only round up to the next rung), but that query
-    // would trap on newIndexBlockLength's capacity guard, so return early.
-    if (blockIndex > 131_071) return;
+    // No shrink is possible for blockIndex >= 2^31: the only rung there
+    // is the top rung 3 * 2^30 (the completely full 2^61 List), where
+    // the index block is at its exactly-full maximal length -- but
+    // newIndexBlockLength would wrap to 0 there and shrink the index
+    // block to nothing, so return early.
+    if (blockIndex >> 31 != 0) return;
     // kind of index of the first block in the super block
     if ((blockIndex << Nat32.bitcountLeadingZero(blockIndex)) << 2 == 0) {
       let newLength = newIndexBlockLength(blockIndex);
@@ -1119,9 +1125,9 @@ module {
     //     case (?element) element;
     //     case (null) Prim.trap "";
     //   };
-    // Nat64-based like locate; for index >= 2^32 the computed block index
-    // is >= 2^17, past any possible index block, so the array access traps
-    // as required (the message just differs from the Nat32 version's).
+    // Nat64-based like locate; for index >= size the block lookup or the
+    // null slot check below traps as required (the message just differs
+    // from the Nat32 version's).
     let i = index.toNat64();
     let lz = Nat64.bitcountLeadingZero(i);
     let lz2 = lz >> 1;
@@ -1154,10 +1160,9 @@ module {
   /// Space: `O(1)`
   public func get<T>(self : List<T>, index : Nat) : ?T {
     // The guard only rejects index >= 2^64, where the wrap conversion
-    // below would alias a small index. Indices in [2^32, 2^64) fall
-    // through to the physical bounds checks: they yield a data block
-    // index >= 2^17, past any possible index block (the List capacity
-    // is 2^32), so `a < blocks.size()` fails and null is returned.
+    // below would alias a small index. Any index >= size falls through
+    // to the physical checks below: a block index beyond blocks.size()
+    // or a null slot, so null is returned.
     if (Prim.shiftRight(index, 64) != 0) return null;
     // inlined version of locate
     let (a, b) = do {
@@ -1191,9 +1196,9 @@ module {
   ///
   /// Runtime: `O(1)`
   public func put<T>(self : List<T>, index : Nat, value : T) {
-    // Nat64-based like locate; for index >= 2^32 the computed block index
-    // is >= 2^17, past any possible index block, so the array access traps
-    // as required (the message just differs from the Nat32 version's).
+    // Nat64-based like locate; for index >= size the block lookup or the
+    // null slot check below traps as required (the message just differs
+    // from the Nat32 version's).
     let i = index.toNat64();
     let lz = Nat64.bitcountLeadingZero(i);
     let lz2 = lz >> 1;

--- a/src/List.mo
+++ b/src/List.mo
@@ -953,6 +953,12 @@ module {
 
   func shrinkIndexBlockIfNeeded<T>(list : List<T>) {
     let blockIndex = Nat.toNat32(list.blockIndex);
+    // At the completely full list the insertion state sits one past the
+    // maximal data block. No shrink is possible there (the index block is
+    // at its exactly-full ladder length, and newIndexBlockLength of the
+    // one-past index could only round up to the next rung), but that query
+    // would trap on newIndexBlockLength's capacity guard, so return early.
+    if (blockIndex > 131_071) return;
     // kind of index of the first block in the super block
     if ((blockIndex << Nat32.bitcountLeadingZero(blockIndex)) << 2 == 0) {
       let newLength = newIndexBlockLength(blockIndex);

--- a/src/List.mo
+++ b/src/List.mo
@@ -1089,14 +1089,17 @@ module {
     //     case (?element) element;
     //     case (null) Prim.trap "";
     //   };
-    let i = Nat.toNat32(index);
-    let lz = Nat32.bitcountLeadingZero(i);
+    // Nat64-based like locate; for index >= 2^32 the computed block index
+    // is >= 2^17, past any possible index block, so the array access traps
+    // as required (the message just differs from the Nat32 version's).
+    let i = index.toNat64();
+    let lz = Nat64.bitcountLeadingZero(i);
     let lz2 = lz >> 1;
     switch (
       if (lz & 1 == 0) {
-        self.blocks[Nat32.toNat(((i << lz2) >> 16) ^ (0x10000 >> lz2))][Nat32.toNat(i & (0xFFFF >> lz2))]
+        self.blocks[(((i << lz2) >> 32) ^ (0x1_0000_0000 >> lz2)).toNat()][(i & (0xFFFF_FFFF >> lz2)).toNat()]
       } else {
-        self.blocks[Nat32.toNat(((i << lz2) >> 15) ^ (0x18000 >> lz2))][Nat32.toNat(i & (0x7FFF >> lz2))]
+        self.blocks[(((i << lz2) >> 31) ^ (0x1_8000_0000 >> lz2)).toNat()][(i & (0x7FFF_FFFF >> lz2)).toNat()]
       }
     ) {
       case (?result) return result;
@@ -1123,13 +1126,14 @@ module {
     if (Prim.shiftRight(index, 32) != 0) return null;
     // inlined version of locate
     let (a, b) = do {
-      let i = Nat32.fromIntWrap(index);
-      let lz = Nat32.bitcountLeadingZero(i);
+      // the guard above ensures index < 2^32, so the wrap cannot trigger
+      let i = Nat64.fromIntWrap(index);
+      let lz = Nat64.bitcountLeadingZero(i);
       let lz2 = lz >> 1;
       if (lz & 1 == 0) {
-        (Nat32.toNat(((i << lz2) >> 16) ^ (0x10000 >> lz2)), Nat32.toNat(i & (0xFFFF >> lz2)))
+        ((((i << lz2) >> 32) ^ (0x1_0000_0000 >> lz2)).toNat(), (i & (0xFFFF_FFFF >> lz2)).toNat())
       } else {
-        (Nat32.toNat(((i << lz2) >> 15) ^ (0x18000 >> lz2)), Nat32.toNat(i & (0x7FFF >> lz2)))
+        ((((i << lz2) >> 31) ^ (0x1_8000_0000 >> lz2)).toNat(), (i & (0x7FFF_FFFF >> lz2)).toNat())
       }
     };
     let blocks = self.blocks;
@@ -1152,13 +1156,16 @@ module {
   ///
   /// Runtime: `O(1)`
   public func put<T>(self : List<T>, index : Nat, value : T) {
-    let i = Nat.toNat32(index);
-    let lz = Nat32.bitcountLeadingZero(i);
+    // Nat64-based like locate; for index >= 2^32 the computed block index
+    // is >= 2^17, past any possible index block, so the array access traps
+    // as required (the message just differs from the Nat32 version's).
+    let i = index.toNat64();
+    let lz = Nat64.bitcountLeadingZero(i);
     let lz2 = lz >> 1;
     let (block, element) = if (lz & 1 == 0) {
-      (self.blocks[Nat32.toNat(((i << lz2) >> 16) ^ (0x10000 >> lz2))], Nat32.toNat(i & (0xFFFF >> lz2)))
+      (self.blocks[(((i << lz2) >> 32) ^ (0x1_0000_0000 >> lz2)).toNat()], (i & (0xFFFF_FFFF >> lz2)).toNat())
     } else {
-      (self.blocks[Nat32.toNat(((i << lz2) >> 15) ^ (0x18000 >> lz2))], Nat32.toNat(i & (0x7FFF >> lz2)))
+      (self.blocks[(((i << lz2) >> 31) ^ (0x1_8000_0000 >> lz2)).toNat()], (i & (0x7FFF_FFFF >> lz2)).toNat())
     };
 
     switch (block[element]) {

--- a/src/List.mo
+++ b/src/List.mo
@@ -2776,9 +2776,13 @@ module {
 
       var j = 0;
       while (j < sz) {
-        switch (db1[j], db2[j]) {
-          case (?x, ?y) if (not equal(x, y)) return false;
-          case (_, _) return true
+        // nested switches only to avoid allocating a tuple for a pair switch
+        switch (db1[j]) {
+          case (?x) switch (db2[j]) {
+            case (?y) if (not equal(x, y)) return false;
+            case null return true
+          };
+          case null return true
         };
         j += 1
       };

--- a/src/List.mo
+++ b/src/List.mo
@@ -44,7 +44,8 @@ module {
   /// will naturally be 2x slower than Buffer and Array. However, Array is not resizable and Buffer
   /// has `O(size)` memory waste.
   ///
-  /// The maximum number of elements in a `List` is 2^32.
+  /// The List size is in practice limited only by available memory; the
+  /// theoretical limit is 2^61 elements.
   public type List<T> = Types.List<T>;
 
   let INTERNAL_ERROR = "List: internal error";
@@ -293,7 +294,8 @@ module {
   /// List.addRepeat(list, 2, 1); // [2, 2, 2, 2, 1, 1]
   /// ```
   ///
-  /// The maximum number of elements in a `List` is 2^32.
+  /// The List size is in practice limited only by available memory; the
+  /// theoretical limit is 2^61 elements.
   ///
   /// Runtime: `O(count)`
   public func addRepeat<T>(self : List<T>, initValue : T, count : Nat) = addRepeatInternal<T>(self, ?initValue, count);
@@ -984,8 +986,8 @@ module {
   /// assert List.toArray(list) == [0, 1, 2, 3];
   /// ```
   ///
-  /// The maximum number of elements in a `List` is 2^32; adding beyond
-  /// that traps.
+  /// The List size is in practice limited only by available memory; the
+  /// theoretical limit is 2^61 elements, beyond which `add` traps.
   ///
   /// Amortized Runtime: `O(1)`, Worst Case Runtime: `O(sqrt(n))`
   public func add<T>(self : List<T>, element : T) {
@@ -1075,17 +1077,16 @@ module {
   };
 
   func locate(index : Nat) : (Nat, Nat) {
-    // see comments in tests
+    // For the derivation of the bit arithmetic see locate_readable64
+    // and locate_optimal64 in test/List.test.mo; the latter is a
+    // verbatim copy of this function and tests its arithmetic across
+    // the full supported range.
     //
-    // Based on Nat64 arithmetic: the halves of the index are 32 bits wide
-    // instead of 16, hence all constants and shift amounts are doubled
-    // compared to the Nat32-based version. The branch parities are
-    // unchanged because 64 - 32 is even.
-    // Unlike the Nat32-based version this also accepts size-valued
-    // arguments, which reach 2^32 for a completely full list (from
-    // prevIndexOf, truncate, repeat/tabulate/addRepeat): locate(2^32)
-    // returns the normalized one-past-the-end position (131_072, 0),
-    // consistent with locate at every smaller data-block boundary.
+    // Also accepts size-valued arguments, one beyond the largest index
+    // in a List (from prevIndexOf, truncate, repeat/tabulate/addRepeat):
+    // e.g. locate(2^32) returns the normalized one-past-the-end position
+    // (131_072, 0), consistent with locate at every smaller data-block
+    // boundary.
     let i = index.toNat64();
     let lz = Nat64.bitcountLeadingZero(i);
     let lz2 = lz >> 1;
@@ -2081,7 +2082,8 @@ module {
   /// assert Iter.toArray(List.values(list)) == [2, 1, 1, 1];
   /// ```
   ///
-  /// The maximum number of elements in a `List` is 2^32.
+  /// The List size is in practice limited only by available memory; the
+  /// theoretical limit is 2^61 elements.
   ///
   /// Runtime: `O(size)`, where n is the size of iter.
   public func addAll<T>(self : List<T>, iter : Types.Iter<T>) {

--- a/src/List.mo
+++ b/src/List.mo
@@ -15,6 +15,7 @@
 import PureList "pure/List";
 import Prim "mo:⛔";
 import Nat32 "Nat32";
+import Nat64 "Nat64";
 import Array "Array";
 import Nat "Nat";
 import Option "Option";
@@ -1100,7 +1101,7 @@ module {
   ///
   /// Space: `O(1)`
   public func get<T>(self : List<T>, index : Nat) : ?T {
-    if (index >= 0x1_0000_0000) return null;
+    if (Nat64.fromIntWrap(index) >> 32 != 0) return null;
     // inlined version of locate
     let (a, b) = do {
       let i = Nat.toNat32(index);

--- a/src/List.mo
+++ b/src/List.mo
@@ -910,6 +910,17 @@ module {
   };
 
   func newIndexBlockLength(blockIndex : Nat32) : Nat {
+    // The maximum List capacity is 2^32 elements, stored in data blocks
+    // 1..131_071; asking to accommodate a block index beyond that means
+    // the capacity would be exceeded. This is the single chokepoint that
+    // all index block growth goes through (add, repeat, tabulate,
+    // addRepeat, ...), and it only executes when the index block actually
+    // grows, so this guard costs one comparison on a path that runs
+    // O(log capacity) times over a list's lifetime — never on ordinary
+    // adds. Without the guard the element would be written successfully
+    // but get() would deny its existence (guarded at index < 2^32),
+    // silently breaking the API's consistency.
+    if (blockIndex > 131_071) Prim.trap "List capacity of 2^32 elements exceeded";
     if (blockIndex <= 1) 2 else {
       let s = 30 - Nat32.bitcountLeadingZero(blockIndex);
       Nat32.toNat(((blockIndex >> s) +% 1) << s)
@@ -959,7 +970,8 @@ module {
   /// assert List.toArray(list) == [0, 1, 2, 3];
   /// ```
   ///
-  /// The maximum number of elements in a `List` is 2^32.
+  /// The maximum number of elements in a `List` is 2^32; adding beyond
+  /// that traps.
   ///
   /// Amortized Runtime: `O(1)`, Worst Case Runtime: `O(sqrt(n))`
   public func add<T>(self : List<T>, element : T) {

--- a/src/List.mo
+++ b/src/List.mo
@@ -873,25 +873,20 @@ module {
     // Each epoch starting with epoch 1 spans exactly two super blocks.
     // Super block s falls in epoch ceil(s/2).
 
-    // epoch of last data block
+    // epoch of position's data block
     // e = 64 - lz
     let lz = Nat64.bitcountLeadingZero(d / 3);
 
     // capacity of all prior epochs combined
-    // capacity_before_e = 2 * 4 ** (e - 1) - 1
+    // capacity_before_e = 2 * 4 ** (e - 1)
 
-    // data blocks in all prior epochs combined
-    // blocks_before_e = 3 * 2 ** (e - 1) - 2
+    // data block indices before epoch e (counting the dummy block 0)
+    // blocks_before_e = 3 * 2 ** (e - 1)
 
     // then size = d * 2 ** e + i - c
-    // where c = blocks_before_e * 2 ** e - capacity_before_e
+    // where c = blocks_before_e * 2 ** e - capacity_before_e = 4 ** e
+    // i.e. size = (d - 2 ** e) * 2 ** e + i, which is the line below
 
-    // The formula is based on Nat64 arithmetic (one epoch further up than
-    // the Nat32-based one would be), like in size(): no intermediate result
-    // overflows for blockIndex <= 2^17. In particular the one-past-the-end
-    // insertion position (131_071, 65_536) of a completely full list maps
-    // correctly to 2^32, which would overflow Nat32.
-    //
     // Intermediate values may exceed 2^64; that is harmless because every
     // operation used (-%, +%, <>>) is a bijection mod 2^64, so the final
     // value is exact whenever the true result fits in 64 bits. A plain >>
@@ -918,26 +913,18 @@ module {
     Nat64.toNat((d -% (1 <>> lz)) <>> lz +% Nat.toNat64(self.elementIndex))
   };
 
+  // Returns the size of data block blockIndex, i.e. 2^e where e is the
+  // epoch of the block. Do not call it for blockIndex == 0.
   func dataBlockSize(blockIndex : Nat) : Nat {
-    // formula for the size of given blockIndex
-    // don't call it for blockIndex == 0
     Nat32.toNat(1 <>> Nat32.bitcountLeadingZero(Nat.toNat32(blockIndex) / 3))
   };
 
-  // The Nat32 arithmetic below bounds the List size to exactly 2^61
-  // elements: it produces valid index block lengths up to and including
-  // the top rung 3 * 2^30, whose index block fills exactly when the List
-  // reaches size 2^61 (insertion state (3 * 2^30, 0)). One step further
-  // the round-up 4 << 30 wraps to 0, so at exactly size 2^61 add traps
-  // with "Array index out of bounds" (growing into the wrapped
-  // zero-length index block) -- the effect of a capacity guard, with a
-  // less descriptive message. All other operations keep working at
-  // size 2^61, including removeLast, whose shrink path dodges the wrap
-  // with the early return in shrinkIndexBlockIfNeeded. Constructor and
-  // addRepeat targets in (2^61, 2^62) hit the same wrap; targets
-  // >= 2^62 trap in the Nat.toNat32 conversions at the call sites. The
-  // bound is theoretical: 2^61 elements need at least 16 EiB of data
-  // blocks, orders of magnitude beyond any real memory.
+  // Returns the length of the index block needed to accommodate data
+  // block blockIndex: the smallest length in the ladder {2^j, 3 * 2^j}
+  // that is strictly greater than blockIndex. Correct for
+  // blockIndex < 3 * 2^30. For blockIndex >= 3 * 2^30 the true result
+  // 2^32 does not fit in Nat32: the round-up 4 << 30 wraps and 0 is
+  // returned (see the size limit section at the end of this file).
   func newIndexBlockLength(blockIndex : Nat32) : Nat {
     if (blockIndex <= 1) 2 else {
       let s = 30 - Nat32.bitcountLeadingZero(blockIndex);
@@ -945,6 +932,8 @@ module {
     }
   };
 
+  // If the index block is exactly full then grow it to the next ladder
+  // length, otherwise do nothing.
   func growIndexBlockIfNeeded<T>(list : List<T>) {
     if (list.blocks.size() == list.blockIndex) {
       let newBlocks = VarArray.repeat<[var ?T]>([var], newIndexBlockLength(Nat.toNat32(list.blockIndex)));
@@ -965,7 +954,8 @@ module {
     // newIndexBlockLength would wrap to 0 there and shrink the index
     // block to nothing, so return early.
     if (blockIndex >> 31 != 0) return;
-    // kind of index of the first block in the super block
+    // only when blockIndex is the first block of a super block (i.e. of
+    // the form 2^j or 3 * 2^j, the index block ladder) can a shrink be due
     if ((blockIndex << Nat32.bitcountLeadingZero(blockIndex)) << 2 == 0) {
       let newLength = newIndexBlockLength(blockIndex);
       if (newLength < list.blocks.size()) {
@@ -3219,5 +3209,24 @@ module {
     };
     next
   };
+
+  // The theoretical size limit of 2^61 elements
+  //
+  // The Nat32 index block arithmetic bounds the List size to exactly
+  // 2^61 elements: newIndexBlockLength is correct up to the top ladder
+  // length 3 * 2^30 (see its contract), and the index block of that
+  // length fills exactly when the List reaches size 2^61 (insertion
+  // state (3 * 2^30, 0)). Growing any further -- add through
+  // growIndexBlockIfNeeded, or constructor and addRepeat targets in
+  // (2^61, 2^62) through their newIndexBlockLength call sites -- builds
+  // the wrapped zero-length index block and traps with "Array index out
+  // of bounds": the effect of a capacity guard, with a less descriptive
+  // message. Targets >= 2^62 trap in the Nat.toNat32 conversions at the
+  // call sites instead. All other operations keep working at size 2^61,
+  // including removeLast, whose shrink path dodges the wrap with the
+  // early return in shrinkIndexBlockIfNeeded. The bound is purely
+  // theoretical: 2^61 elements need at least 16 EiB of data blocks.
+  // test/List.indexBlock.test.mo exercises the machinery at this bound
+  // with width-scaled (Nat8) copies of these functions.
 
 }

--- a/test/List.allocation.test.mo
+++ b/test/List.allocation.test.mo
@@ -29,8 +29,6 @@
 // - truncate/clear: (re)allocate index blocks
 // - sortInPlace/sort: O(size) scratch array
 // - binarySearch: allocates its variant result (112 B)
-// - find: allocates one closure per call (40 B)
-// - equal/compare: allocate ~40 B per element (tuple in `switch (a, b)`)
 
 import List "../src/List";
 import Nat "../src/Nat";
@@ -40,6 +38,8 @@ import { test } "mo:test";
 let n = 1_000;
 // Read-only list with distinct, sorted elements 0..n-1.
 let list = List.tabulate<Nat>(n, func i = i);
+// Equal copy of `list`, for equal/compare full scans.
+let listCopy = List.tabulate<Nat>(n, func i = i);
 
 // Runs `f` once to trigger any one-time allocations, then measures the
 // bytes allocated by a second run.
@@ -104,6 +104,7 @@ assertNoAlloc("List.last", func() { var i = 0; while (i < n) { ignore List.last(
 
 // --- Search (full scans; targets/predicates chosen so no early exit) ---
 
+assertNoAlloc("List.find", func() { ignore List.find<Nat>(list, func x = x == 999) });
 assertNoAlloc("List.findIndex", func() { ignore List.findIndex<Nat>(list, func x = x == 999) });
 assertNoAlloc("List.findLastIndex", func() { ignore List.findLastIndex<Nat>(list, func x = x == 0) });
 assertNoAlloc("List.indexOf", func() { ignore List.indexOf<Nat>(list, Nat.equal, 999) });
@@ -113,6 +114,8 @@ assertNoAlloc("List.prevIndexOf", func() { ignore List.prevIndexOf<Nat>(list, Na
 assertNoAlloc("List.contains", func() { ignore List.contains<Nat>(list, Nat.equal, n) });
 assertNoAlloc("List.all", func() { ignore List.all<Nat>(list, func x = x < n) });
 assertNoAlloc("List.any", func() { ignore List.any<Nat>(list, func x = x >= n) });
+// assertNoAlloc("List.equal", func() { ignore List.equal<Nat>(list, listCopy, Nat.equal) });
+// assertNoAlloc("List.compare", func() { ignore List.compare<Nat>(list, listCopy, Nat.compare) });
 
 // --- Aggregation ---
 

--- a/test/List.allocation.test.mo
+++ b/test/List.allocation.test.mo
@@ -1,0 +1,183 @@
+// @testmode wasi
+
+// Asserts that the zero-allocation List functions stay zero-allocation, so
+// that later commits don't accidentally introduce allocations on hot paths.
+//
+// `Prim.rts_total_allocation()` is a monotonic counter of all bytes ever
+// allocated, so a zero delta around a code section proves it allocated
+// nothing (independent of GC). This requires wasi test mode (real RTS); in
+// the interpreter the counter is not maintained — the "allocation is
+// detected" harness test below fails in that case, so a wrong test mode
+// cannot produce silent false passes.
+//
+// Notes on methodology:
+// - Each workload is run once as a warm-up before measuring, so one-time
+//   lazy allocations are not counted; the assertion is about steady-state
+//   per-call behavior.
+// - Elements are small scalar Nats, so the element values themselves never
+//   allocate; what is measured is the List function's own overhead.
+// - Callback lambdas must not capture test-local state: capture-free
+//   lambdas are static (allocation-free), while a capturing lambda is
+//   allocated at its creation site. Callbacks below only reference
+//   file-scope bindings, which are static.
+//
+// Deliberately absent, because these functions do allocate (as measured
+// with moc 1.11.1, see git history of this file):
+// - all constructors and converters (empty, repeat, clone, toArray, ...)
+//   and all functions returning new lists, arrays, iterators or Text
+// - add/removeLast: amortized — allocate when crossing block boundaries
+// - truncate/clear: (re)allocate index blocks
+// - sortInPlace/sort: O(size) scratch array
+// - binarySearch: allocates its variant result (112 B)
+// - find: allocates one closure per call (40 B)
+// - equal/compare: allocate ~40 B per element (tuple in `switch (a, b)`)
+
+import List "../src/List";
+import Nat "../src/Nat";
+import Prim "mo:prim";
+import { test } "mo:test";
+
+let n = 1_000;
+// Read-only list with distinct, sorted elements 0..n-1.
+let list = List.tabulate<Nat>(n, func i = i);
+
+// Runs `f` once to trigger any one-time allocations, then measures the
+// bytes allocated by a second run.
+func allocDelta(f : () -> ()) : Nat {
+  f();
+  let before = Prim.rts_total_allocation();
+  f();
+  let after = Prim.rts_total_allocation();
+  after - before
+};
+
+func assertNoAlloc(name : Text, f : () -> ()) {
+  test(
+    name # " does not allocate",
+    func() {
+      let delta = allocDelta(f);
+      if (delta != 0) Prim.debugPrint("NONZERO " # name # ": " # Nat.toText(delta));
+      assert delta == 0
+    }
+  )
+};
+
+// --- Harness validation ---
+
+test(
+  "measurement harness: empty loop does not allocate",
+  func() {
+    let delta = allocDelta(
+      func() {
+        var i = 0;
+        while (i < n) { i += 1 }
+      }
+    );
+    assert delta == 0
+  }
+);
+
+test(
+  "measurement harness: allocation is detected",
+  func() {
+    var r : [var Nat] = [var];
+    let delta = allocDelta(
+      func() {
+        r := Prim.Array_init<Nat>(8, 0)
+      }
+    );
+    assert delta > 0
+  }
+);
+
+// --- Size queries ---
+
+assertNoAlloc("List.size", func() { var i = 0; while (i < n) { ignore List.size(list); i += 1 } });
+assertNoAlloc("List.isEmpty", func() { var i = 0; while (i < n) { ignore List.isEmpty(list); i += 1 } });
+
+// --- Element access ---
+
+assertNoAlloc("List.at", func() { var i = 0; while (i < n) { ignore List.at(list, i); i += 1 } });
+assertNoAlloc("List.get", func() { var i = 0; while (i < n) { ignore List.get(list, i); i += 1 } });
+assertNoAlloc("List.first", func() { var i = 0; while (i < n) { ignore List.first(list); i += 1 } });
+assertNoAlloc("List.last", func() { var i = 0; while (i < n) { ignore List.last(list); i += 1 } });
+
+// --- Search (full scans; targets/predicates chosen so no early exit) ---
+
+assertNoAlloc("List.findIndex", func() { ignore List.findIndex<Nat>(list, func x = x == 999) });
+assertNoAlloc("List.findLastIndex", func() { ignore List.findLastIndex<Nat>(list, func x = x == 0) });
+assertNoAlloc("List.indexOf", func() { ignore List.indexOf<Nat>(list, Nat.equal, 999) });
+assertNoAlloc("List.nextIndexOf", func() { ignore List.nextIndexOf<Nat>(list, Nat.equal, 999, 0) });
+assertNoAlloc("List.lastIndexOf", func() { ignore List.lastIndexOf<Nat>(list, Nat.equal, 0) });
+assertNoAlloc("List.prevIndexOf", func() { ignore List.prevIndexOf<Nat>(list, Nat.equal, 0, n) });
+assertNoAlloc("List.contains", func() { ignore List.contains<Nat>(list, Nat.equal, n) });
+assertNoAlloc("List.all", func() { ignore List.all<Nat>(list, func x = x < n) });
+assertNoAlloc("List.any", func() { ignore List.any<Nat>(list, func x = x >= n) });
+
+// --- Aggregation ---
+
+assertNoAlloc("List.max", func() { ignore List.max<Nat>(list, Nat.compare) });
+assertNoAlloc("List.min", func() { ignore List.min<Nat>(list, Nat.compare) });
+assertNoAlloc("List.isSorted", func() { ignore List.isSorted<Nat>(list, Nat.compare) });
+assertNoAlloc("List.foldLeft", func() { ignore List.foldLeft<Nat, Nat>(list, 0, func(a, x) = a + x) });
+assertNoAlloc("List.foldRight", func() { ignore List.foldRight<Nat, Nat>(list, 0, func(x, a) = a + x) });
+
+// --- Iteration (callback style; the iterator-returning functions allocate) ---
+
+assertNoAlloc("List.forEach", func() { List.forEach<Nat>(list, func _ = ()) });
+assertNoAlloc("List.forEachEntry", func() { List.forEachEntry<Nat>(list, func(_, _) = ()) });
+assertNoAlloc("List.reverseForEach", func() { List.reverseForEach<Nat>(list, func _ = ()) });
+assertNoAlloc("List.reverseForEachEntry", func() { List.reverseForEachEntry<Nat>(list, func(_, _) = ()) });
+assertNoAlloc("List.forEachInRange", func() { List.forEachInRange<Nat>(list, func _ = (), 0, n) });
+
+// --- In-place mutation (each on its own list, so the shared read-only
+//     `list` above keeps its distinct sorted elements) ---
+
+test(
+  "List.put does not allocate",
+  func() {
+    let l = List.repeat<Nat>(0, n);
+    assert allocDelta(func() { var i = 0; while (i < n) { List.put(l, i, i); i += 1 } }) == 0
+  }
+);
+
+test(
+  "List.fill does not allocate",
+  func() {
+    let l = List.repeat<Nat>(0, n);
+    assert allocDelta(func() { List.fill(l, 7) }) == 0
+  }
+);
+
+test(
+  "List.mapInPlace does not allocate",
+  func() {
+    let l = List.repeat<Nat>(0, n);
+    assert allocDelta(func() { List.mapInPlace<Nat>(l, func x = x) }) == 0
+  }
+);
+
+test(
+  "List.retain does not allocate",
+  func() {
+    let l = List.repeat<Nat>(0, n);
+    assert allocDelta(func() { List.retain<Nat>(l, func _ = true) }) == 0
+  }
+);
+
+test(
+  "List.deduplicate does not allocate",
+  func() {
+    // distinct elements, so the workload is idempotent (nothing is removed)
+    let l = List.tabulate<Nat>(n, func i = i);
+    assert allocDelta(func() { List.deduplicate<Nat>(l, Nat.equal) }) == 0
+  }
+);
+
+test(
+  "List.reverseInPlace does not allocate",
+  func() {
+    let l = List.tabulate<Nat>(n, func i = i);
+    assert allocDelta(func() { List.reverseInPlace(l); List.reverseInPlace(l) }) == 0
+  }
+)

--- a/test/List.allocation.test.mo
+++ b/test/List.allocation.test.mo
@@ -105,8 +105,11 @@ assertNoAlloc("List.last", func() { var i = 0; while (i < n) { ignore List.last(
 // --- Search (full scans; targets/predicates chosen so no early exit) ---
 
 assertNoAlloc("List.find", func() { ignore List.find<Nat>(list, func x = x == 999) });
+assertNoAlloc("List.find (no hit)", func() { ignore List.find<Nat>(list, func x = x >= n) });
 assertNoAlloc("List.findIndex", func() { ignore List.findIndex<Nat>(list, func x = x == 999) });
+assertNoAlloc("List.findIndex (no hit)", func() { ignore List.findIndex<Nat>(list, func x = x >= n) });
 assertNoAlloc("List.findLastIndex", func() { ignore List.findLastIndex<Nat>(list, func x = x == 0) });
+assertNoAlloc("List.findLastIndex (no hit)", func() { ignore List.findLastIndex<Nat>(list, func x = x >= n) });
 assertNoAlloc("List.indexOf", func() { ignore List.indexOf<Nat>(list, Nat.equal, 999) });
 assertNoAlloc("List.nextIndexOf", func() { ignore List.nextIndexOf<Nat>(list, Nat.equal, 999, 0) });
 assertNoAlloc("List.lastIndexOf", func() { ignore List.lastIndexOf<Nat>(list, Nat.equal, 0) });

--- a/test/List.allocation.test.mo
+++ b/test/List.allocation.test.mo
@@ -115,7 +115,7 @@ assertNoAlloc("List.contains", func() { ignore List.contains<Nat>(list, Nat.equa
 assertNoAlloc("List.all", func() { ignore List.all<Nat>(list, func x = x < n) });
 assertNoAlloc("List.any", func() { ignore List.any<Nat>(list, func x = x >= n) });
 assertNoAlloc("List.equal", func() { ignore List.equal<Nat>(list, listCopy, Nat.equal) });
-// assertNoAlloc("List.compare", func() { ignore List.compare<Nat>(list, listCopy, Nat.compare) });
+assertNoAlloc("List.compare", func() { ignore List.compare<Nat>(list, listCopy, Nat.compare) });
 
 // --- Aggregation ---
 

--- a/test/List.allocation.test.mo
+++ b/test/List.allocation.test.mo
@@ -114,7 +114,7 @@ assertNoAlloc("List.prevIndexOf", func() { ignore List.prevIndexOf<Nat>(list, Na
 assertNoAlloc("List.contains", func() { ignore List.contains<Nat>(list, Nat.equal, n) });
 assertNoAlloc("List.all", func() { ignore List.all<Nat>(list, func x = x < n) });
 assertNoAlloc("List.any", func() { ignore List.any<Nat>(list, func x = x >= n) });
-// assertNoAlloc("List.equal", func() { ignore List.equal<Nat>(list, listCopy, Nat.equal) });
+assertNoAlloc("List.equal", func() { ignore List.equal<Nat>(list, listCopy, Nat.equal) });
 // assertNoAlloc("List.compare", func() { ignore List.compare<Nat>(list, listCopy, Nat.compare) });
 
 // --- Aggregation ---

--- a/test/List.indexBlock.test.mo
+++ b/test/List.indexBlock.test.mo
@@ -81,7 +81,8 @@ func shrinkIndexBlockIfNeeded<T>(list : List.List<T>) {
   // newIndexBlockLength would wrap to 0 there and shrink the index
   // block to nothing, so return early.
   if (blockIndex >> 7 != 0) return;
-  // kind of index of the first block in the super block
+  // only when blockIndex is the first block of a super block (i.e. of
+  // the form 2^j or 3 * 2^j, the index block ladder) can a shrink be due
   if ((blockIndex << Nat8.bitcountLeadingZero(blockIndex)) << 2 == 0) {
     let newLength = newIndexBlockLength(blockIndex);
     if (newLength < list.blocks.size()) {

--- a/test/List.indexBlock.test.mo
+++ b/test/List.indexBlock.test.mo
@@ -75,6 +75,8 @@ func growIndexBlockIfNeeded<T>(list : List.List<T>) {
 
 func shrinkIndexBlockIfNeeded<T>(list : List.List<T>) {
   let blockIndex = Nat.toNat8(list.blockIndex);
+  // (comment verbatim from src/List.mo; in this Nat8-scaled copy the
+  // threshold is 2^7, the top rung 3 * 2^6 and the full size 2^13)
   // No shrink is possible for blockIndex >= 2^31: the only rung there
   // is the top rung 3 * 2^30 (the completely full 2^61 List), where
   // the index block is at its exactly-full maximal length -- but

--- a/test/List.indexBlock.test.mo
+++ b/test/List.indexBlock.test.mo
@@ -1,43 +1,69 @@
 // @testmode wasi
 
-// Exercises index block growth and shrinking at the maximum block index.
-// At the real capacity boundary the index block has 131_072 entries and
-// the list 2^32 elements (~32 GB), so this cannot be tested directly.
-// Instead the functions below are 1-1 copies of their src/List.mo
-// counterparts (dataBlockSize, newIndexBlockLength, growIndexBlockIfNeeded,
-// shrinkIndexBlockIfNeeded, add, removeLast) with a single change: the
-// capacity guard's threshold 131_071 is scaled down to 47. That gives max
-// data block index 47, maximum index block length 48 and capacity
-// 2 * 4^4 = 512 elements, so the boundary machinery runs for real on
-// 512-element lists. KEEP THE COPIES IN SYNC WITH src/List.mo.
+// Exercises the index block machinery at its Nat32 size bound, which
+// caps the List at exactly 2^61 elements (see the comment on
+// newIndexBlockLength in src/List.mo). The bound is unreachable
+// directly (2^61 elements; even a faked top state needs a ~26 GB index
+// block), so the functions below are 1-1 copies of their src/List.mo
+// counterparts (dataBlockSize, newIndexBlockLength,
+// growIndexBlockIfNeeded, shrinkIndexBlockIfNeeded, add, removeLast)
+// with a single change: Nat32 is narrowed to Nat8 (the offsets 30 -> 6
+// and 31 -> 7, and the conversions accordingly). That moves the bound
+// from the top rung 3 * 2^30 (size 2^61) down to 3 * 2^6 = 192
+// (size 2^13 = 8_192), so the boundary machinery runs for real on
+// 8_192-element lists. KEEP THE COPIES IN SYNC WITH src/List.mo.
 //
 // The copies operate on the real List<T> record, so the real List.size /
 // List.at can be used for assertions on the same list.
+//
+// The two trapping behaviors at the bound (add at the full size, and
+// the index block corruption that the early return in
+// shrinkIndexBlockIfNeeded prevents) cannot be asserted here because a
+// trap aborts the whole wasi test run; they were verified manually with
+// these same copies.
 
 import List "../src/List";
+import Nat8 "../src/Nat8";
 import Nat32 "../src/Nat32";
 import Nat "../src/Nat";
 import VarArray "../src/VarArray";
-import Prim "mo:⛔";
 import { test } "mo:test";
 
-// ---- 1-1 copies from src/List.mo, scaled: guard threshold 131_071 -> 47 ----
-
-func dataBlockSize(blockIndex : Nat) : Nat {
-  Nat32.toNat(1 <>> Nat32.bitcountLeadingZero(Nat.toNat32(blockIndex) / 3))
-};
-
-func newIndexBlockLength(blockIndex : Nat32) : Nat {
-  if (blockIndex > 47) Prim.trap "List capacity of 512 elements exceeded";
+// verbatim copy (only renamed) of newIndexBlockLength from src/List.mo,
+// probing the Nat32 arithmetic at the real bound
+func newIndexBlockLength32(blockIndex : Nat32) : Nat {
   if (blockIndex <= 1) 2 else {
     let s = 30 - Nat32.bitcountLeadingZero(blockIndex);
     Nat32.toNat(((blockIndex >> s) +% 1) << s)
   }
 };
 
+test(
+  "Nat32 rung arithmetic at the top",
+  func() {
+    assert newIndexBlockLength32(131_072) == 196_608; // an ordinary rung
+    assert newIndexBlockLength32(2_147_483_648) == 3_221_225_472; // 2^31 -> top rung 3*2^30
+    assert newIndexBlockLength32(3_221_225_471) == 3_221_225_472; // last valid input
+    assert newIndexBlockLength32(3_221_225_472) == 0 // top rung: 4 << 30 wraps
+  }
+);
+
+// ---- 1-1 copies from src/List.mo, narrowed: Nat32 -> Nat8 ----
+
+func dataBlockSize(blockIndex : Nat) : Nat {
+  Nat8.toNat(1 <>> Nat8.bitcountLeadingZero(Nat.toNat8(blockIndex) / 3))
+};
+
+func newIndexBlockLength(blockIndex : Nat8) : Nat {
+  if (blockIndex <= 1) 2 else {
+    let s = 6 - Nat8.bitcountLeadingZero(blockIndex);
+    Nat8.toNat(((blockIndex >> s) +% 1) << s)
+  }
+};
+
 func growIndexBlockIfNeeded<T>(list : List.List<T>) {
   if (list.blocks.size() == list.blockIndex) {
-    let newBlocks = VarArray.repeat<[var ?T]>([var], newIndexBlockLength(Nat.toNat32(list.blockIndex)));
+    let newBlocks = VarArray.repeat<[var ?T]>([var], newIndexBlockLength(Nat.toNat8(list.blockIndex)));
     var i = 0;
     while (i < list.blockIndex) {
       newBlocks[i] := list.blocks[i];
@@ -48,15 +74,15 @@ func growIndexBlockIfNeeded<T>(list : List.List<T>) {
 };
 
 func shrinkIndexBlockIfNeeded<T>(list : List.List<T>) {
-  let blockIndex = Nat.toNat32(list.blockIndex);
-  // At the completely full list the insertion state sits one past the
-  // maximal data block. No shrink is possible there (the index block is
-  // at its exactly-full ladder length, and newIndexBlockLength of the
-  // one-past index could only round up to the next rung), but that query
-  // would trap on newIndexBlockLength's capacity guard, so return early.
-  if (blockIndex > 47) return;
+  let blockIndex = Nat.toNat8(list.blockIndex);
+  // No shrink is possible for blockIndex >= 2^31: the only rung there
+  // is the top rung 3 * 2^30 (the completely full 2^61 List), where
+  // the index block is at its exactly-full maximal length -- but
+  // newIndexBlockLength would wrap to 0 there and shrink the index
+  // block to nothing, so return early.
+  if (blockIndex >> 7 != 0) return;
   // kind of index of the first block in the super block
-  if ((blockIndex << Nat32.bitcountLeadingZero(blockIndex)) << 2 == 0) {
+  if ((blockIndex << Nat8.bitcountLeadingZero(blockIndex)) << 2 == 0) {
     let newLength = newIndexBlockLength(blockIndex);
     if (newLength < list.blocks.size()) {
       let newBlocks = VarArray.repeat<[var ?T]>([var], newLength);
@@ -126,136 +152,66 @@ func removeLast<T>(self : List.List<T>) : ?T {
   return element
 };
 
-// ---- tests against the real src/List.mo at the real boundary ----
-//
-// On this branch the maximal index block has 131_072 entries (~1 MB), so
-// states at the real capacity boundary can be crafted directly and driven
-// through the REAL functions. Only full traversal of the growth ladder
-// needs the scaled copies below.
+// ---- tests ----
+
+// the scaled maximum size: end of epoch 6, insertion state (192, 0)
+let maxSize = 8_192;
+
+func fullList() : List.List<Nat> {
+  let l = List.empty<Nat>();
+  var i = 0;
+  while (i < maxSize) { add(l, i); i += 1 };
+  l
+};
 
 test(
-  "real grow to the maximal index block length",
+  "the maximum size is reached intact",
   func() {
-    // a real list of size 2^31 has the state (98_304, 0) with the index
-    // block exactly full at length 98_304; the next add grows the index
-    // block to its maximal length 131_072
-    let fake : List.List<Nat> = {
-      var blocks = VarArray.repeat<[var ?Nat]>([var], 98_304);
-      var blockIndex = 98_304;
-      var elementIndex = 0
-    };
-    List.add(fake, 7);
-    assert fake.blocks.size() == 131_072;
-    assert List.size(fake) == 2_147_483_649; // 2^31 + 1
-    assert List.at(fake, 2_147_483_648) == 7
-  }
-);
-
-test(
-  "real removeLast from the completely full 2^32 list",
-  func() {
-    // the shrink path runs at the one-past-the-end state (131_072, 0),
-    // where newIndexBlockLength's capacity guard must not fire
-    let dataBlocks = VarArray.repeat<[var ?Nat]>([var], 131_072);
-    dataBlocks[131_071] := VarArray.repeat<?Nat>(?7, 65_536);
-    let fake : List.List<Nat> = {
-      var blocks = dataBlocks;
-      var blockIndex = 131_072;
-      var elementIndex = 0
-    };
-    assert List.removeLast(fake) == ?7;
-    assert List.size(fake) == 4_294_967_295; // 2^32 - 1
-    assert fake.blockIndex == 131_071;
-    assert fake.blocks.size() == 131_072 // no shrink possible at the top
-  }
-);
-
-test(
-  "real shrink of the maximal index block",
-  func() {
-    // state (65_536, 0) (size 2^30) with the index block still at its
-    // maximal length, as after draining from full without an intervening
-    // shrink opportunity; the next removeLast crosses the rung 65_536 and
-    // shrinks the index block to 98_304
-    let dataBlocks = VarArray.repeat<[var ?Nat]>([var], 131_072);
-    dataBlocks[65_535] := VarArray.repeat<?Nat>(?7, 32_768);
-    let fake : List.List<Nat> = {
-      var blocks = dataBlocks;
-      var blockIndex = 65_536;
-      var elementIndex = 0
-    };
-    assert List.removeLast(fake) == ?7;
-    assert fake.blocks.size() == 98_304;
-    assert List.size(fake) == 1_073_741_823 // 2^30 - 1
-  }
-);
-
-// ---- tests (scaled copies) ----
-
-let capacity = 512;
-
-test(
-  "grow to the (scaled) maximum: index block reaches its exactly-full length",
-  func() {
-    let l = List.empty<Nat>();
-    var i = 0;
-    while (i < capacity) {
-      add(l, i);
-      i += 1
-    };
-    assert List.size(l) == capacity;
-    assert l.blockIndex == 48;
+    let l = fullList();
+    assert List.size(l) == maxSize;
+    assert l.blockIndex == 192;
     assert l.elementIndex == 0;
-    assert l.blocks.size() == 48; // exactly full, no slack at capacity
+    assert l.blocks.size() == 192; // exactly full at the top rung
     assert List.at(l, 0) == 0;
-    assert List.at(l, 511) == 511
+    assert List.at(l, maxSize - 1) == maxSize - 1
   }
 );
 
 test(
-  "removeLast from the completely full list works and drains with shrinking",
+  "removeLast at the maximum size works via the early return",
   func() {
-    let l = List.empty<Nat>();
-    var i = 0;
-    while (i < capacity) {
-      add(l, i);
-      i += 1
-    };
+    let l = fullList();
+    assert removeLast(l) == ?(maxSize - 1);
+    assert List.size(l) == maxSize - 1;
+    assert l.blocks.size() == 192 // untouched: no shrink possible at the top
+  }
+);
 
-    // the very first removeLast runs shrinkIndexBlockIfNeeded at the
-    // one-past-the-end state (48, 0), where newIndexBlockLength's
-    // capacity guard must not fire
-    assert removeLast(l) == ?511;
-    assert List.size(l) == 511;
-
-    var expected = 510;
+test(
+  "full drain from the maximum size shrinks the index block",
+  func() {
+    let l = fullList();
+    var expected = maxSize - 1 : Nat;
     while (List.size(l) > 0) {
       assert removeLast(l) == ?expected;
       if (expected > 0) expected -= 1
     };
-    assert List.size(l) == 0;
     assert removeLast(l) == null;
-    // the index block shrank on the way down
-    assert l.blocks.size() < 48
+    assert l.blocks.size() < 192
   }
 );
 
 test(
-  "add/removeLast cycle at the capacity boundary does not trap",
+  "add/removeLast cycle at the maximum size",
   func() {
-    let l = List.empty<Nat>();
-    var i = 0;
-    while (i < capacity) {
-      add(l, i);
-      i += 1
-    };
+    let l = fullList();
     var k = 0;
     while (k < 3) {
-      assert removeLast(l) == ?511;
-      add(l, 511);
+      assert removeLast(l) == ?(maxSize - 1);
+      add(l, maxSize - 1);
       k += 1
     };
-    assert List.size(l) == capacity;
-    assert List.at(l, 511) == 511
+    assert List.size(l) == maxSize;
+    assert List.at(l, maxSize - 1) == maxSize - 1
   }
 )

--- a/test/List.indexBlock.test.mo
+++ b/test/List.indexBlock.test.mo
@@ -1,0 +1,255 @@
+// @testmode wasi
+
+// Exercises index block growth and shrinking at the maximum block index.
+// At the real capacity boundary the index block has 131_072 entries and
+// the list 2^32 elements (~32 GB), so this cannot be tested directly.
+// Instead the functions below are 1-1 copies of their src/List.mo
+// counterparts (dataBlockSize, newIndexBlockLength, growIndexBlockIfNeeded,
+// shrinkIndexBlockIfNeeded, add, removeLast) with a single change: the
+// capacity guard's threshold 131_071 is scaled down to 47. That gives max
+// data block index 47, maximum index block length 48 and capacity
+// 2 * 4^4 = 512 elements, so the boundary machinery runs for real on
+// 512-element lists. KEEP THE COPIES IN SYNC WITH src/List.mo.
+//
+// The copies operate on the real List<T> record, so the real List.size /
+// List.at can be used for assertions on the same list.
+
+import List "../src/List";
+import Nat32 "../src/Nat32";
+import Nat "../src/Nat";
+import VarArray "../src/VarArray";
+import Prim "mo:⛔";
+import { test } "mo:test";
+
+// ---- 1-1 copies from src/List.mo, scaled: guard threshold 131_071 -> 47 ----
+
+func dataBlockSize(blockIndex : Nat) : Nat {
+  Nat32.toNat(1 <>> Nat32.bitcountLeadingZero(Nat.toNat32(blockIndex) / 3))
+};
+
+func newIndexBlockLength(blockIndex : Nat32) : Nat {
+  if (blockIndex > 47) Prim.trap "List capacity of 512 elements exceeded";
+  if (blockIndex <= 1) 2 else {
+    let s = 30 - Nat32.bitcountLeadingZero(blockIndex);
+    Nat32.toNat(((blockIndex >> s) +% 1) << s)
+  }
+};
+
+func growIndexBlockIfNeeded<T>(list : List.List<T>) {
+  if (list.blocks.size() == list.blockIndex) {
+    let newBlocks = VarArray.repeat<[var ?T]>([var], newIndexBlockLength(Nat.toNat32(list.blockIndex)));
+    var i = 0;
+    while (i < list.blockIndex) {
+      newBlocks[i] := list.blocks[i];
+      i += 1
+    };
+    list.blocks := newBlocks
+  }
+};
+
+func shrinkIndexBlockIfNeeded<T>(list : List.List<T>) {
+  let blockIndex = Nat.toNat32(list.blockIndex);
+  // kind of index of the first block in the super block
+  if ((blockIndex << Nat32.bitcountLeadingZero(blockIndex)) << 2 == 0) {
+    let newLength = newIndexBlockLength(blockIndex);
+    if (newLength < list.blocks.size()) {
+      let newBlocks = VarArray.repeat<[var ?T]>([var], newLength);
+      var i = 0;
+      while (i < newLength) {
+        newBlocks[i] := list.blocks[i];
+        i += 1
+      };
+      list.blocks := newBlocks
+    }
+  }
+};
+
+func add<T>(self : List.List<T>, element : T) {
+  var elementIndex = self.elementIndex;
+  if (elementIndex == 0) {
+    growIndexBlockIfNeeded(self);
+    let blockIndex = self.blockIndex;
+
+    // When removing last we keep one more data block, so can be not empty
+    if (self.blocks[blockIndex].size() == 0) {
+      self.blocks[blockIndex] := VarArray.repeat<?T>(
+        null,
+        dataBlockSize(blockIndex)
+      )
+    }
+  };
+
+  let lastDataBlock = self.blocks[self.blockIndex];
+
+  lastDataBlock[elementIndex] := ?element;
+
+  elementIndex += 1;
+  if (elementIndex == lastDataBlock.size()) {
+    elementIndex := 0;
+    self.blockIndex += 1
+  };
+  self.elementIndex := elementIndex
+};
+
+func removeLast<T>(self : List.List<T>) : ?T {
+  var elementIndex = self.elementIndex;
+  if (elementIndex == 0) {
+    var blockIndex = self.blockIndex;
+    if (blockIndex == 1) {
+      return null
+    };
+
+    shrinkIndexBlockIfNeeded(self);
+
+    blockIndex -= 1;
+    elementIndex := self.blocks[blockIndex].size();
+
+    // Keep one totally empty block when removing
+    if (blockIndex + 2 < self.blocks.size()) self.blocks[blockIndex + 2] := [var];
+
+    self.blockIndex := blockIndex
+  };
+  elementIndex -= 1;
+
+  let lastDataBlock = self.blocks[self.blockIndex];
+
+  let element = lastDataBlock[elementIndex];
+  lastDataBlock[elementIndex] := null;
+
+  self.elementIndex := elementIndex;
+  return element
+};
+
+// ---- tests against the real src/List.mo at the real boundary ----
+//
+// On this branch the maximal index block has 131_072 entries (~1 MB), so
+// states at the real capacity boundary can be crafted directly and driven
+// through the REAL functions. Only full traversal of the growth ladder
+// needs the scaled copies below.
+
+test(
+  "real grow to the maximal index block length",
+  func() {
+    // a real list of size 2^31 has the state (98_304, 0) with the index
+    // block exactly full at length 98_304; the next add grows the index
+    // block to its maximal length 131_072
+    let fake : List.List<Nat> = {
+      var blocks = VarArray.repeat<[var ?Nat]>([var], 98_304);
+      var blockIndex = 98_304;
+      var elementIndex = 0
+    };
+    List.add(fake, 7);
+    assert fake.blocks.size() == 131_072;
+    assert List.size(fake) == 2_147_483_649; // 2^31 + 1
+    assert List.at(fake, 2_147_483_648) == 7
+  }
+);
+
+test(
+  "real removeLast from the completely full 2^32 list",
+  func() {
+    // the shrink path runs at the one-past-the-end state (131_072, 0),
+    // where newIndexBlockLength's capacity guard must not fire
+    let dataBlocks = VarArray.repeat<[var ?Nat]>([var], 131_072);
+    dataBlocks[131_071] := VarArray.repeat<?Nat>(?7, 65_536);
+    let fake : List.List<Nat> = {
+      var blocks = dataBlocks;
+      var blockIndex = 131_072;
+      var elementIndex = 0
+    };
+    assert List.removeLast(fake) == ?7;
+    assert List.size(fake) == 4_294_967_295; // 2^32 - 1
+    assert fake.blockIndex == 131_071;
+    assert fake.blocks.size() == 131_072 // no shrink possible at the top
+  }
+);
+
+test(
+  "real shrink of the maximal index block",
+  func() {
+    // state (65_536, 0) (size 2^30) with the index block still at its
+    // maximal length, as after draining from full without an intervening
+    // shrink opportunity; the next removeLast crosses the rung 65_536 and
+    // shrinks the index block to 98_304
+    let dataBlocks = VarArray.repeat<[var ?Nat]>([var], 131_072);
+    dataBlocks[65_535] := VarArray.repeat<?Nat>(?7, 32_768);
+    let fake : List.List<Nat> = {
+      var blocks = dataBlocks;
+      var blockIndex = 65_536;
+      var elementIndex = 0
+    };
+    assert List.removeLast(fake) == ?7;
+    assert fake.blocks.size() == 98_304;
+    assert List.size(fake) == 1_073_741_823 // 2^30 - 1
+  }
+);
+
+// ---- tests (scaled copies) ----
+
+let capacity = 512;
+
+test(
+  "grow to the (scaled) maximum: index block reaches its exactly-full length",
+  func() {
+    let l = List.empty<Nat>();
+    var i = 0;
+    while (i < capacity) {
+      add(l, i);
+      i += 1
+    };
+    assert List.size(l) == capacity;
+    assert l.blockIndex == 48;
+    assert l.elementIndex == 0;
+    assert l.blocks.size() == 48; // exactly full, no slack at capacity
+    assert List.at(l, 0) == 0;
+    assert List.at(l, 511) == 511
+  }
+);
+
+test(
+  "removeLast from the completely full list works and drains with shrinking",
+  func() {
+    let l = List.empty<Nat>();
+    var i = 0;
+    while (i < capacity) {
+      add(l, i);
+      i += 1
+    };
+
+    // the very first removeLast runs shrinkIndexBlockIfNeeded at the
+    // one-past-the-end state (48, 0), where newIndexBlockLength's
+    // capacity guard must not fire
+    assert removeLast(l) == ?511;
+    assert List.size(l) == 511;
+
+    var expected = 510;
+    while (List.size(l) > 0) {
+      assert removeLast(l) == ?expected;
+      if (expected > 0) expected -= 1
+    };
+    assert List.size(l) == 0;
+    assert removeLast(l) == null;
+    // the index block shrank on the way down
+    assert l.blocks.size() < 48
+  }
+);
+
+test(
+  "add/removeLast cycle at the capacity boundary does not trap",
+  func() {
+    let l = List.empty<Nat>();
+    var i = 0;
+    while (i < capacity) {
+      add(l, i);
+      i += 1
+    };
+    var k = 0;
+    while (k < 3) {
+      assert removeLast(l) == ?511;
+      add(l, 511);
+      k += 1
+    };
+    assert List.size(l) == capacity;
+    assert List.at(l, 511) == 511
+  }
+)

--- a/test/List.indexBlock.test.mo
+++ b/test/List.indexBlock.test.mo
@@ -49,6 +49,12 @@ func growIndexBlockIfNeeded<T>(list : List.List<T>) {
 
 func shrinkIndexBlockIfNeeded<T>(list : List.List<T>) {
   let blockIndex = Nat.toNat32(list.blockIndex);
+  // At the completely full list the insertion state sits one past the
+  // maximal data block. No shrink is possible there (the index block is
+  // at its exactly-full ladder length, and newIndexBlockLength of the
+  // one-past index could only round up to the next rung), but that query
+  // would trap on newIndexBlockLength's capacity guard, so return early.
+  if (blockIndex > 47) return;
   // kind of index of the first block in the super block
   if ((blockIndex << Nat32.bitcountLeadingZero(blockIndex)) << 2 == 0) {
     let newLength = newIndexBlockLength(blockIndex);

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -2251,12 +2251,21 @@ Test.suite(
   }
 );
 
+// Constructs a List record with crafted internal state and blockCount
+// empty data block slots, for the fake tests below. Individual slots can
+// be populated through the returned record's blocks field.
+func fakeList(blockCount : Nat, blockIndex : Nat, elementIndex : Nat) : List.List<Nat> = {
+  var blocks = VarArray.repeat<[var ?Nat]>([var], blockCount);
+  var blockIndex = blockIndex;
+  var elementIndex = elementIndex
+};
+
 // A size as large as 2^32 cannot be reached by actually adding elements
 // (32 GB of data blocks), so these tests craft the List's internal state
 // directly. size() derives the size purely from the (blockIndex,
 // elementIndex) insertion position, so the data blocks can remain empty.
-// The crafted states follow the pattern of real full lists, checked
-// against reachable sizes: a full list of size 2^(2m) has
+// The crafted states follow the pattern of real lists at these sizes,
+// checked against reachable sizes: a list of size 2^(2m) has
 // blockIndex = 2^(m+1) and elementIndex = 0 (e.g. size 2^24 has
 // blockIndex = 8192); the state one element earlier is
 // blockIndex = 2^(m+1) - 1, elementIndex = lastBlockSize - 1.
@@ -2266,29 +2275,21 @@ Test.suite(
     Test.test(
       "size 2^32 - 1",
       func() {
-        let almostFull : List.List<Nat> = {
-          var blocks = [var] : [var [var ?Nat]];
-          var blockIndex = 131_071;
-          var elementIndex = 65_535
-        };
-        Test.expect.nat(List.size(almostFull)).equal(4_294_967_295)
+        let midBlock = fakeList(0, 131_071, 65_535);
+        Test.expect.nat(List.size(midBlock)).equal(4_294_967_295)
       }
     );
     Test.test(
       "size 2^32 (one-past state (131_072, 0))",
       func() {
-        let full : List.List<Nat> = {
-          var blocks = [var] : [var [var ?Nat]];
-          var blockIndex = 131_072;
-          var elementIndex = 0
-        };
-        Test.expect.nat(List.size(full)).equal(4_294_967_296)
+        let atBlockBoundary = fakeList(0, 131_072, 0);
+        Test.expect.nat(List.size(atBlockBoundary)).equal(4_294_967_296)
       }
     )
   }
 );
 
-// binarySearch on a faked completely full list of size 2^32 (see the size
+// binarySearch on a faked list of size 2^32 (see the size
 // tests above for the crafted blockIndex/elementIndex values). A real list
 // of this size would need ~32 GB, but binarySearch only reads O(log n)
 // slots, so only the data blocks actually hit by the search are
@@ -2306,13 +2307,14 @@ Test.suite(
 // traps when read (empty block or unwrap of null), so this test also
 // asserts the exact probe set of the search.
 Test.suite(
-  "binarySearch on a faked full 2^32 list",
+  "binarySearch on a faked 2^32 list",
   func() {
     Test.test(
       "finds the last element",
       func() {
         let target = 4_294_967_295; // == the last index; all other probed slots hold 0
-        let dataBlocks = VarArray.repeat<[var ?Nat]>([var], 131_072);
+        let fake = fakeList(131_072, 131_072, 0);
+        let dataBlocks = fake.blocks;
 
         // phase 1 probe
         dataBlocks[98_304] := [var ?0];
@@ -2343,12 +2345,6 @@ Test.suite(
         lastBlock[65_535] := ?target;
         dataBlocks[131_071] := lastBlock;
 
-        let fake : List.List<Nat> = {
-          var blocks = dataBlocks;
-          var blockIndex = 131_072;
-          var elementIndex = 0
-        };
-
         let result = List.binarySearch(fake, Nat.compare, target);
         Test.expect.bool(result == #found(4_294_967_295)).equal(true)
       }
@@ -2362,7 +2358,8 @@ Test.suite(
         // the one-past-the-end index of this list, verifying
         // indexByBlockElement's Nat64 arithmetic at the first value
         // beyond every valid element index.
-        let dataBlocks = VarArray.repeat<[var ?Nat]>([var], 131_072);
+        let fake = fakeList(131_072, 131_072, 0);
+        let dataBlocks = fake.blocks;
         dataBlocks[98_304] := [var ?0];
         var left = 98_304;
         let right = 131_072;
@@ -2381,12 +2378,6 @@ Test.suite(
           l := mid + 1
         };
         dataBlocks[131_071] := lastBlock;
-
-        let fake : List.List<Nat> = {
-          var blocks = dataBlocks;
-          var blockIndex = 131_072;
-          var elementIndex = 0
-        };
 
         switch (List.binarySearch(fake, Nat.compare, 1)) {
           case (#insertionIndex i) Test.expect.nat(i).equal(4_294_967_296);
@@ -2413,15 +2404,11 @@ Test.suite(
       func() {
         // fake list; only the last slot holds a (matching) element,
         // so the backward scan succeeds on its first probe
-        let dataBlocks = VarArray.repeat<[var ?Nat]>([var], 131_072);
+        let fake = fakeList(131_072, 131_072, 0);
+        let dataBlocks = fake.blocks;
         let lastBlock = VarArray.repeat<?Nat>(null, 65_536);
         lastBlock[65_535] := ?7;
         dataBlocks[131_071] := lastBlock;
-        let fake : List.List<Nat> = {
-          var blocks = dataBlocks;
-          var blockIndex = 131_072;
-          var elementIndex = 0
-        };
         switch (List.lastIndexOf<Nat>(fake, Nat.equal, 7)) {
           case (?i) Test.expect.nat(i).equal(4_294_967_295);
           case null Test.expect.nat(0).equal(4_294_967_295) // fails informatively
@@ -2431,11 +2418,7 @@ Test.suite(
     Test.test(
       "truncate to the current size 2^32 is a no-op",
       func() {
-        let fake : List.List<Nat> = {
-          var blocks = VarArray.repeat<[var ?Nat]>([var], 131_072);
-          var blockIndex = 131_072;
-          var elementIndex = 0
-        };
+        let fake = fakeList(131_072, 131_072, 0);
         List.truncate(fake, 4_294_967_296);
         Test.expect.nat(List.size(fake)).equal(4_294_967_296)
       }
@@ -2443,11 +2426,7 @@ Test.suite(
     Test.test(
       "addRepeat of zero elements at size 2^32 is a no-op",
       func() {
-        let fake : List.List<Nat> = {
-          var blocks = VarArray.repeat<[var ?Nat]>([var], 131_072);
-          var blockIndex = 131_072;
-          var elementIndex = 0
-        };
+        let fake = fakeList(131_072, 131_072, 0);
         List.addRepeat(fake, 7, 0);
         Test.expect.nat(List.size(fake)).equal(4_294_967_296)
       }

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -2221,4 +2221,116 @@ Test.suite(
       }
     )
   }
+);
+
+// binarySearch on a faked completely full list of size 2^32 (see the size
+// tests above for the crafted blockIndex/elementIndex values). A real list
+// of this size would need ~32 GB, but binarySearch only reads O(log n)
+// slots, so only the data blocks actually hit by the search are
+// instantiated, and only as long as needed:
+// - phase 1 (epoch scan) probes blocks[3 * 2^(epoch-1)][0]; searching for
+//   the maximum it stops at the first probe: blocks[98_304][0]
+//   (b = 131_071, epoch = 32 - lz32(b/3) = 16, lessOrEqual = 2^16/2)
+// - phase 2 bisects block indices in [98_304, 131_072) reading only
+//   slot 0 of each probed block, so those blocks have length 1; every
+//   probe compares #less because the target is the maximum
+// - phase 3 bisects inside block 131_071; its `right` bound is the
+//   block's PHYSICAL size, so this one block must be full-length (65_536)
+// The probed slots hold ?0 (any value < target keeps the outcomes #less);
+// the target sits in the very last slot. Every slot NOT instantiated
+// traps when read (empty block or unwrap of null), so this test also
+// asserts the exact probe set of the search.
+Test.suite(
+  "binarySearch on a faked full 2^32 list",
+  func() {
+    Test.test(
+      "finds the last element",
+      func() {
+        let target = 4_294_967_295; // == the last index; all other probed slots hold 0
+        let dataBlocks = VarArray.repeat<[var ?Nat]>([var], 131_072);
+
+        // phase 1 probe
+        dataBlocks[98_304] := [var ?0];
+
+        // phase 2 probes: replicate the bisection index arithmetic,
+        // outcome is #less (left := mid) at every step
+        var left = 98_304;
+        var right = 131_072;
+        while (right - left : Nat > 1) {
+          let mid = (left + right) / 2;
+          dataBlocks[mid] := [var ?0];
+          left := mid
+        };
+        // left is now 131_071, the block holding the last element
+
+        // phase 3 probes inside the (full-length) last block,
+        // outcome is #less (left := mid + 1) until the final probe
+        let lastBlock = VarArray.repeat<?Nat>(null, 65_536);
+        lastBlock[0] := ?0; // probed by phase 2 (its final mid is 131_071)
+        var l = 0;
+        var r = 65_536;
+        label sim while (l != r) {
+          let mid = (l + r) / 2;
+          if (mid == 65_535) break sim;
+          lastBlock[mid] := ?0;
+          l := mid + 1
+        };
+        lastBlock[65_535] := ?target;
+        dataBlocks[131_071] := lastBlock;
+
+        let fake : List.List<Nat> = {
+          var blocks = dataBlocks;
+          var blockIndex = 131_072;
+          var elementIndex = 0
+        };
+
+        let result = List.binarySearch(fake, Nat.compare, target);
+        Test.expect.bool(result == #found(4_294_967_295)).equal(true)
+      }
+    );
+    Test.test(
+      "insertion point past the last element",
+      func() {
+        // Same fake and probe set as above, but every probed slot (including
+        // the very last one) holds 0 and we search for 1, which is greater
+        // than everything: the search must report insertion index 2^32.
+        // This is the one case where indexByBlockElement's Nat32 arithmetic
+        // overflows: blockStart(131_071) + 65_536 = 2^32 wraps to 0, so a
+        // caller would be told to insert the LARGEST element at the FRONT.
+        // (Any list shorter than the full 2^32 yields insertion indices
+        // < 2^32, which fit Nat32 — only the completely full list is
+        // affected.)
+        let dataBlocks = VarArray.repeat<[var ?Nat]>([var], 131_072);
+        dataBlocks[98_304] := [var ?0];
+        var left = 98_304;
+        let right = 131_072;
+        while (right - left : Nat > 1) {
+          let mid = (left + right) / 2;
+          dataBlocks[mid] := [var ?0];
+          left := mid
+        };
+        let lastBlock = VarArray.repeat<?Nat>(null, 65_536);
+        lastBlock[0] := ?0;
+        var l = 0;
+        let r = 65_536;
+        while (l != r) {
+          let mid = (l + r) / 2;
+          lastBlock[mid] := ?0;
+          l := mid + 1
+        };
+        dataBlocks[131_071] := lastBlock;
+
+        let fake : List.List<Nat> = {
+          var blocks = dataBlocks;
+          var blockIndex = 131_072;
+          var elementIndex = 0
+        };
+
+        switch (List.binarySearch(fake, Nat.compare, 1)) {
+          case (#insertionIndex i) Test.expect.nat(i).equal(4_294_967_296);
+          case (#found i) Test.expect.nat(i).equal(4_294_967_296) // unreachable; fails informatively
+        }
+      }
+    )
+  }
 )

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -2393,4 +2393,76 @@ Test.suite(
       }
     )
   }
+);
+
+// The index block grows and shrinks along a ladder of exactly-full
+// lengths (the "rungs" {2^j, 3*2^j}): growth rounds the block index up
+// to the next rung and shrinking is checked at rung crossings only.
+// These tests drive add/removeLast through the full ladder below 512
+// elements and assert the resulting index block lengths.
+Test.suite(
+  "index block grow/shrink ladder",
+  func() {
+    Test.test(
+      "growing reaches an exactly-full index block at a rung",
+      func() {
+        let l = List.empty<Nat>();
+        var i = 0;
+        while (i < 512) {
+          List.add(l, i);
+          i += 1
+        };
+        assert List.size(l) == 512;
+        assert l.blockIndex == 48;
+        assert l.elementIndex == 0;
+        assert l.blocks.size() == 48; // exactly full at the rung
+        assert List.at(l, 0) == 0;
+        assert List.at(l, 511) == 511
+      }
+    );
+    Test.test(
+      "draining from a rung state shrinks the index block",
+      func() {
+        let l = List.empty<Nat>();
+        var i = 0;
+        while (i < 512) {
+          List.add(l, i);
+          i += 1
+        };
+        // the first removeLast runs shrinkIndexBlockIfNeeded at the rung
+        // state (48, 0), where newIndexBlockLength rounds up to 64 and the
+        // newLength < blocks.size() filter rejects the shrink
+        assert List.removeLast(l) == ?511;
+        assert List.size(l) == 511;
+        var expected = 510;
+        while (List.size(l) > 0) {
+          assert List.removeLast(l) == ?expected;
+          if (expected > 0) expected -= 1
+        };
+        assert List.size(l) == 0;
+        assert List.removeLast(l) == null;
+        // the index block shrank on the way down
+        assert l.blocks.size() < 48
+      }
+    );
+    Test.test(
+      "add/removeLast cycle at a rung boundary",
+      func() {
+        let l = List.empty<Nat>();
+        var i = 0;
+        while (i < 512) {
+          List.add(l, i);
+          i += 1
+        };
+        var k = 0;
+        while (k < 3) {
+          assert List.removeLast(l) == ?511;
+          List.add(l, 511);
+          k += 1
+        };
+        assert List.size(l) == 512;
+        assert List.at(l, 511) == 511
+      }
+    )
+  }
 )

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -2333,8 +2333,7 @@ Test.suite(
       }
     )
   }
-)
-;
+);
 
 // Operations whose argument is a SIZE (not an index) must accept the value
 // 2^32 — the size of a completely full list. Internally they pass it to

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -2334,3 +2334,64 @@ Test.suite(
     )
   }
 )
+;
+
+// Operations whose argument is a SIZE (not an index) must accept the value
+// 2^32 — the size of a completely full list. Internally they pass it to
+// locate(), whose Nat32 conversion can only express indices (<= 2^32 - 1),
+// so today all three trap with "losing precision". locate(2^32) must
+// return the normalized one-past-the-end position (131_072, 0), like it
+// already does at every smaller data-block boundary (e.g. locate(8) is
+// the start of the next block).
+// The same defect makes repeat/tabulate/addRepeat trap when constructing
+// a list of size exactly 2^32; that case has no value-asserting test
+// because a successful construction needs ~32 GB of data blocks.
+Test.suite(
+  "size-valued arguments at the 2^32 capacity boundary",
+  func() {
+    Test.test(
+      "lastIndexOf scans from the very end",
+      func() {
+        // fake full list; only the last slot holds a (matching) element,
+        // so the backward scan succeeds on its first probe
+        let dataBlocks = VarArray.repeat<[var ?Nat]>([var], 131_072);
+        let lastBlock = VarArray.repeat<?Nat>(null, 65_536);
+        lastBlock[65_535] := ?7;
+        dataBlocks[131_071] := lastBlock;
+        let fake : List.List<Nat> = {
+          var blocks = dataBlocks;
+          var blockIndex = 131_072;
+          var elementIndex = 0
+        };
+        switch (List.lastIndexOf<Nat>(fake, Nat.equal, 7)) {
+          case (?i) Test.expect.nat(i).equal(4_294_967_295);
+          case null Test.expect.nat(0).equal(4_294_967_295) // fails informatively
+        }
+      }
+    );
+    Test.test(
+      "truncate to the current size 2^32 is a no-op",
+      func() {
+        let fake : List.List<Nat> = {
+          var blocks = VarArray.repeat<[var ?Nat]>([var], 131_072);
+          var blockIndex = 131_072;
+          var elementIndex = 0
+        };
+        List.truncate(fake, 4_294_967_296);
+        Test.expect.nat(List.size(fake)).equal(4_294_967_296)
+      }
+    );
+    Test.test(
+      "addRepeat of zero elements at full capacity is a no-op",
+      func() {
+        let fake : List.List<Nat> = {
+          var blocks = VarArray.repeat<[var ?Nat]>([var], 131_072);
+          var blockIndex = 131_072;
+          var elementIndex = 0
+        };
+        List.addRepeat(fake, 7, 0);
+        Test.expect.nat(List.size(fake)).equal(4_294_967_296)
+      }
+    )
+  }
+)

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -7,6 +7,7 @@ import Prim "mo:⛔";
 import Iter "../src/Iter";
 import Array "../src/Array";
 import Nat32 "../src/Nat32";
+import Nat64 "../src/Nat64";
 import Nat "../src/Nat";
 import Order "../src/Order";
 import List "../src/List";
@@ -118,6 +119,70 @@ while (i < locate_n) {
   assert (locate_readable(2 ** 32 - 1 - i : Nat) == locate_optimal(2 ** 32 - 1 - i : Nat));
   i += 1
 };
+
+// The Nat64 widening of locate_readable: bit length 64, so super block
+// s = 63 - lz; the mask derivation is unchanged.
+func locate_readable64<X>(index : Nat) : (Nat, Nat) {
+  let i = Nat.toNat64(index);
+  if (i == 0) {
+    return (1, 0)
+  };
+  let lz = Nat64.bitcountLeadingZero(i);
+  let s = 63 - lz;
+  let down = s >> 1;
+  let up = (s + 1) >> 1;
+  let e_mask = 1 << up - 1;
+  let b_mask = 1 << down - 1;
+  (Nat64.toNat(e_mask + b_mask + 2 + (i >> up) & b_mask), Nat64.toNat(i & e_mask))
+};
+
+// Verbatim copy of the private locate in src/List.mo, the shipped Nat64
+// version of locate_optimal. KEEP IN SYNC WITH src/List.mo.
+func locate_optimal64<X>(index : Nat) : (Nat, Nat) {
+  let i = index.toNat64();
+  let lz = Nat64.bitcountLeadingZero(i);
+  let lz2 = lz >> 1;
+  if (lz & 1 == 0) {
+    ((((i << lz2) >> 32) ^ (0x1_0000_0000 >> lz2)).toNat(), (i & (0xFFFF_FFFF >> lz2)).toNat())
+  } else {
+    ((((i << lz2) >> 31) ^ (0x1_8000_0000 >> lz2)).toNat(), (i & (0x7FFF_FFFF >> lz2)).toNat())
+  }
+};
+
+// link the Nat64 spec to the Nat32 spec below 2^32, and check the
+// shipped arithmetic against the Nat64 spec on the same ranges
+i := 0;
+while (i < locate_n) {
+  assert (locate_readable64(i) == locate_readable(i));
+  assert (locate_readable64(2 ** 32 - 1 - i : Nat) == locate_readable(2 ** 32 - 1 - i : Nat));
+  assert (locate_readable64(i) == locate_optimal64(i));
+  assert (locate_readable64(2 ** 32 - 1 - i : Nat) == locate_optimal64(2 ** 32 - 1 - i : Nat));
+  i += 1
+};
+
+// boundaries across the full supported range up to the maximum size
+// 2^61: neighborhoods of every power 2^k and of the odd-power interior
+// boundary 3 * 2^(k-1); the values above each boundary include the
+// size-valued arguments at data block boundaries
+var k = 1;
+while (k <= 61) {
+  let p = 2 ** k;
+  let q = 3 * 2 ** (k - 1 : Nat);
+  var d = 0;
+  while (d < 8) {
+    if (p + d <= 2 ** 61) assert (locate_readable64(p + d) == locate_optimal64(p + d));
+    if (d < p) assert (locate_readable64(p - d - 1 : Nat) == locate_optimal64(p - d - 1 : Nat));
+    if (q + d <= 2 ** 61) assert (locate_readable64(q + d) == locate_optimal64(q + d));
+    if (d < q) assert (locate_readable64(q - d - 1 : Nat) == locate_optimal64(q - d - 1 : Nat));
+    d += 1
+  };
+  k += 1
+};
+
+// anchors: the one-past-the-end positions of the 2^32 list and of the
+// maximal 2^61 list
+assert (locate_optimal64(2 ** 32) == (131_072, 0));
+assert (locate_optimal64(2 ** 61) == (3 * 2 ** 30, 0));
 
 // IMPLEMENTATION DETAILS END
 
@@ -2186,7 +2251,7 @@ Test.suite(
   }
 );
 
-// The maximum size 2^32 cannot be reached by actually adding elements
+// A size as large as 2^32 cannot be reached by actually adding elements
 // (32 GB of data blocks), so these tests craft the List's internal state
 // directly. size() derives the size purely from the (blockIndex,
 // elementIndex) insertion position, so the data blocks can remain empty.
@@ -2196,7 +2261,7 @@ Test.suite(
 // blockIndex = 8192); the state one element earlier is
 // blockIndex = 2^(m+1) - 1, elementIndex = lastBlockSize - 1.
 Test.suite(
-  "size at the 2^32 capacity boundary",
+  "size at 2^32",
   func() {
     Test.test(
       "size 2^32 - 1",
@@ -2210,7 +2275,7 @@ Test.suite(
       }
     );
     Test.test(
-      "size 2^32 (completely full list)",
+      "size 2^32 (one-past state (131_072, 0))",
       func() {
         let full : List.List<Nat> = {
           var blocks = [var] : [var [var ?Nat]];
@@ -2293,13 +2358,10 @@ Test.suite(
       func() {
         // Same fake and probe set as above, but every probed slot (including
         // the very last one) holds 0 and we search for 1, which is greater
-        // than everything: the search must report insertion index 2^32.
-        // This is the one case where indexByBlockElement's Nat32 arithmetic
-        // overflows: blockStart(131_071) + 65_536 = 2^32 wraps to 0, so a
-        // caller would be told to insert the LARGEST element at the FRONT.
-        // (Any list shorter than the full 2^32 yields insertion indices
-        // < 2^32, which fit Nat32 — only the completely full list is
-        // affected.)
+        // than everything: the search must report insertion index 2^32 --
+        // the one-past-the-end index of this list, verifying
+        // indexByBlockElement's Nat64 arithmetic at the first value
+        // beyond every valid element index.
         let dataBlocks = VarArray.repeat<[var ?Nat]>([var], 131_072);
         dataBlocks[98_304] := [var ?0];
         var left = 98_304;
@@ -2335,23 +2397,21 @@ Test.suite(
   }
 );
 
-// Operations whose argument is a SIZE (not an index) must accept the value
-// 2^32 — the size of a completely full list. Internally they pass it to
-// locate(), whose Nat32 conversion can only express indices (<= 2^32 - 1),
-// so today all three trap with "losing precision". locate(2^32) must
-// return the normalized one-past-the-end position (131_072, 0), like it
-// already does at every smaller data-block boundary (e.g. locate(8) is
-// the start of the next block).
-// The same defect makes repeat/tabulate/addRepeat trap when constructing
-// a list of size exactly 2^32; that case has no value-asserting test
-// because a successful construction needs ~32 GB of data blocks.
+// These tests probe the value 2^32 on a fake list of that size:
+// locate(2^32) returns the normalized
+// one-past-the-end position (131_072, 0), like locate does at every
+// smaller data-block boundary (e.g. locate(8) is the start of the next
+// block), and all three operations succeed.
+// (Constructing a real list of size 2^32 with repeat/tabulate/
+// addRepeat has no value-asserting test because a successful
+// construction needs ~32 GB of data blocks.)
 Test.suite(
-  "size-valued arguments at the 2^32 capacity boundary",
+  "size-valued arguments at size 2^32",
   func() {
     Test.test(
       "lastIndexOf scans from the very end",
       func() {
-        // fake full list; only the last slot holds a (matching) element,
+        // fake list; only the last slot holds a (matching) element,
         // so the backward scan succeeds on its first probe
         let dataBlocks = VarArray.repeat<[var ?Nat]>([var], 131_072);
         let lastBlock = VarArray.repeat<?Nat>(null, 65_536);
@@ -2381,7 +2441,7 @@ Test.suite(
       }
     );
     Test.test(
-      "addRepeat of zero elements at full capacity is a no-op",
+      "addRepeat of zero elements at size 2^32 is a no-op",
       func() {
         let fake : List.List<Nat> = {
           var blocks = VarArray.repeat<[var ?Nat]>([var], 131_072);

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -2184,4 +2184,41 @@ Test.suite(
       }
     )
   }
+);
+
+// The maximum size 2^32 cannot be reached by actually adding elements
+// (32 GB of data blocks), so these tests craft the List's internal state
+// directly. size() derives the size purely from the (blockIndex,
+// elementIndex) insertion position, so the data blocks can remain empty.
+// The crafted states follow the pattern of real full lists, checked
+// against reachable sizes: a full list of size 2^(2m) has
+// blockIndex = 2^(m+1) and elementIndex = 0 (e.g. size 2^24 has
+// blockIndex = 8192); the state one element earlier is
+// blockIndex = 2^(m+1) - 1, elementIndex = lastBlockSize - 1.
+Test.suite(
+  "size at the 2^32 capacity boundary",
+  func() {
+    Test.test(
+      "size 2^32 - 1",
+      func() {
+        let almostFull : List.List<Nat> = {
+          var blocks = [var] : [var [var ?Nat]];
+          var blockIndex = 131_071;
+          var elementIndex = 65_535
+        };
+        Test.expect.nat(List.size(almostFull)).equal(4_294_967_295)
+      }
+    );
+    Test.test(
+      "size 2^32 (completely full list)",
+      func() {
+        let full : List.List<Nat> = {
+          var blocks = [var] : [var [var ?Nat]];
+          var blockIndex = 131_072;
+          var elementIndex = 0
+        };
+        Test.expect.nat(List.size(full)).equal(4_294_967_296)
+      }
+    )
+  }
 )


### PR DESCRIPTION
Adds an allocation-regression test (wasi testmode) that measures Prim.rts_total_allocation() around each List function that is allocation-free today and asserts a zero delta, so later commits cannot accidentally introduce allocations on hot paths.

Covers 31 functions including get. Deliberately absent because they currently allocate: find (40 B closure per call) and equal/compare (~40 B per element); to be fixed and added in follow-up commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `List` bounds handling for very large indexes and extreme capacities, including safer out-of-range access behavior.
  * Updated `List` core indexing/size math to use wider numeric handling and refined edge-case semantics.
* **Tests**
  * Added a zero-allocation-focused `List` test suite covering common read and in-place operations.
  * Expanded capacity and boundary coverage around the `2^32` edge, including growth/shrink and Nat64 cross-checks.
* **Documentation**
  * Reordered upcoming changelog items for readability.
* **Chores**
  * Extended CI tests with an additional legacy persistence run and updated CI tooling version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->