### PR TITLE
Raise the maximum List size from 2^32 to 2^61

### DIFF
--- a/src/List.mo
+++ b/src/List.mo
@@ -4,8 +4,10 @@
 ///
 /// Performance note: on a 64-bit build (enhanced orthogonal persistence, the
 /// compiler default) all index and size arithmetic in this module operates on
-/// unboxed values over the entire supported size range (up to 2^32 elements),
-/// so there are no boxing-related performance cliffs or hidden allocations.
+/// unboxed values over the entire supported size range (the capacity of 2^61
+/// elements is unreachable in practice anyway: at 8 bytes per element memory
+/// is exhausted long before), so there are no boxing-related performance
+/// cliffs or hidden allocations.
 /// On a 32-bit build (deprecated legacy persistence) `Nat` values >= 2^30 are
 /// boxed, so an operation receiving such an index, or internally computing
 /// such a size, would take slower bignum code paths and allocate a few dozen
@@ -41,7 +43,7 @@ module {
   /// will naturally be 2x slower than Buffer and Array. However, Array is not resizable and Buffer
   /// has `O(size)` memory waste.
   ///
-  /// The maximum number of elements in a `List` is 2^32.
+  /// The maximum number of elements in a `List` is 2^61.
   public type List<T> = Types.List<T>;
 
   let INTERNAL_ERROR = "List: internal error";
@@ -290,7 +292,7 @@ module {
   /// List.addRepeat(list, 2, 1); // [2, 2, 2, 2, 1, 1]
   /// ```
   ///
-  /// The maximum number of elements in a `List` is 2^32.
+  /// The maximum number of elements in a `List` is 2^61.
   ///
   /// Runtime: `O(count)`
   public func addRepeat<T>(self : List<T>, initValue : T, count : Nat) = addRepeatInternal<T>(self, ?initValue, count);
@@ -884,10 +886,9 @@ module {
     // where c = blocks_before_e * 2 ** e - capacity_before_e
 
     // The formula is based on Nat64 arithmetic (one epoch further up than
-    // the Nat32-based one would be), like in size(): no intermediate result
-    // overflows for blockIndex <= 2^17. In particular the one-past-the-end
-    // insertion position (131_071, 65_536) of a completely full list maps
-    // correctly to 2^32, which would overflow Nat32.
+    // the Nat32-based one would be), like in size(). In particular the
+    // one-past-the-end insertion position (3 * 2^30 - 1, 2^30) of a
+    // completely full list maps correctly to the maximum size 2^61.
     //
     // Intermediate values may exceed 2^64; that is harmless because every
     // operation used (-%, +%, <>>) is a bijection mod 2^64, so the final
@@ -922,17 +923,23 @@ module {
   };
 
   func newIndexBlockLength(blockIndex : Nat32) : Nat {
-    // The maximum List capacity is 2^32 elements, stored in data blocks
-    // 1..131_071; asking to accommodate a block index beyond that means
-    // the capacity would be exceeded. This is the single chokepoint that
-    // all index block growth goes through (add, repeat, tabulate,
+    // The maximum List capacity is 2^61 elements, stored in data blocks
+    // 1..(3 * 2^30 - 1); asking to accommodate a block index beyond that
+    // means the capacity would be exceeded. This is the single chokepoint
+    // that all index block growth goes through (add, repeat, tabulate,
     // addRepeat, ...), and it only executes when the index block actually
     // grows, so this guard costs one comparison on a path that runs
     // O(log capacity) times over a list's lifetime — never on ordinary
-    // adds. Without the guard the element would be written successfully
-    // but get() would deny its existence (guarded at index < 2^32),
-    // silently breaking the API's consistency.
-    if (blockIndex > 131_071) Prim.trap "List capacity of 2^32 elements exceeded";
+    // adds. 2^61 is the largest full-epoch capacity for which the Nat32
+    // arithmetic below stays exact: the rounded-up index block length
+    // 3 * 2^30 is the largest representable ladder value (the next one,
+    // 2^32, would overflow). Requests so large that even the block index
+    // exceeds 32 bits trap earlier, at the Nat.toNat32 conversions at the
+    // call sites.
+    // The shift tests blockIndex >= 3 * 2^30, i.e. the top two bits both
+    // set. This covers arbitrary jump targets from the constructors, not
+    // just the incrementally growing add path.
+    if (blockIndex >> 30 == 3) Prim.trap "List capacity of 2^61 elements exceeded";
     if (blockIndex <= 1) 2 else {
       let s = 30 - Nat32.bitcountLeadingZero(blockIndex);
       Nat32.toNat(((blockIndex >> s) +% 1) << s)
@@ -982,7 +989,7 @@ module {
   /// assert List.toArray(list) == [0, 1, 2, 3];
   /// ```
   ///
-  /// The maximum number of elements in a `List` is 2^32; adding beyond
+  /// The maximum number of elements in a `List` is 2^61; adding beyond
   /// that traps.
   ///
   /// Amortized Runtime: `O(1)`, Worst Case Runtime: `O(sqrt(n))`
@@ -1080,9 +1087,9 @@ module {
     // compared to the Nat32-based version. The branch parities are
     // unchanged because 64 - 32 is even.
     // Unlike the Nat32-based version this also accepts size-valued
-    // arguments, which reach 2^32 for a completely full list (from
-    // prevIndexOf, truncate, repeat/tabulate/addRepeat): locate(2^32)
-    // returns the normalized one-past-the-end position (131_072, 0),
+    // arguments, which reach 2^61 for a completely full list (from
+    // prevIndexOf, truncate, repeat/tabulate/addRepeat): locate(2^61)
+    // returns the normalized one-past-the-end position (3 * 2^30, 0),
     // consistent with locate at every smaller data-block boundary.
     let i = index.toNat64();
     let lz = Nat64.bitcountLeadingZero(i);
@@ -1113,9 +1120,9 @@ module {
     //     case (?element) element;
     //     case (null) Prim.trap "";
     //   };
-    // Nat64-based like locate; for index >= 2^32 the computed block index
-    // is >= 2^17, past any possible index block, so the array access traps
-    // as required (the message just differs from the Nat32 version's).
+    // Nat64-based like locate; for index >= 2^61 the computed block index
+    // is >= 3 * 2^30, past any possible index block (the List capacity is
+    // 2^61), so the array access traps as required.
     let i = index.toNat64();
     let lz = Nat64.bitcountLeadingZero(i);
     let lz2 = lz >> 1;
@@ -1148,10 +1155,10 @@ module {
   /// Space: `O(1)`
   public func get<T>(self : List<T>, index : Nat) : ?T {
     // The guard only rejects index >= 2^64, where the wrap conversion
-    // below would alias a small index. Indices in [2^32, 2^64) fall
+    // below would alias a small index. Indices in [2^61, 2^64) fall
     // through to the physical bounds checks: they yield a data block
-    // index >= 2^17, past any possible index block (the List capacity
-    // is 2^32), so `a < blocks.size()` fails and null is returned.
+    // index >= 3 * 2^30, past any possible index block (the List capacity
+    // is 2^61), so `a < blocks.size()` fails and null is returned.
     if (Prim.shiftRight(index, 64) != 0) return null;
     // inlined version of locate
     let (a, b) = do {
@@ -1185,9 +1192,9 @@ module {
   ///
   /// Runtime: `O(1)`
   public func put<T>(self : List<T>, index : Nat, value : T) {
-    // Nat64-based like locate; for index >= 2^32 the computed block index
-    // is >= 2^17, past any possible index block, so the array access traps
-    // as required (the message just differs from the Nat32 version's).
+    // Nat64-based like locate; for index >= 2^61 the computed block index
+    // is >= 3 * 2^30, past any possible index block (the List capacity is
+    // 2^61), so the array access traps as required.
     let i = index.toNat64();
     let lz = Nat64.bitcountLeadingZero(i);
     let lz2 = lz >> 1;
@@ -2080,7 +2087,7 @@ module {
   /// assert Iter.toArray(List.values(list)) == [2, 1, 1, 1];
   /// ```
   ///
-  /// The maximum number of elements in a `List` is 2^32.
+  /// The maximum number of elements in a `List` is 2^61.
   ///
   /// Runtime: `O(size)`, where n is the size of iter.
   public func addAll<T>(self : List<T>, iter : Types.Iter<T>) {

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -2045,7 +2045,7 @@ Test.suite(
     );
 
     Test.test(
-      "get returns null for index >= 2^32",
+      "get returns null for out-of-range indices, however large",
       func() {
         Test.expect.bool(List.get<Nat>(vec, 4294967296) == null).equal(true);
         Test.expect.bool(List.get<Nat>(vec, 100) == null).equal(true);
@@ -2186,7 +2186,7 @@ Test.suite(
   }
 );
 
-// The maximum size 2^32 cannot be reached by actually adding elements
+// A size of 2^32 cannot be reached by actually adding elements
 // (32 GB of data blocks), so these tests craft the List's internal state
 // directly. size() derives the size purely from the (blockIndex,
 // elementIndex) insertion position, so the data blocks can remain empty.
@@ -2196,7 +2196,7 @@ Test.suite(
 // blockIndex = 8192); the state one element earlier is
 // blockIndex = 2^(m+1) - 1, elementIndex = lastBlockSize - 1.
 Test.suite(
-  "size at the 2^32 capacity boundary",
+  "size at 2^32 (the former capacity boundary)",
   func() {
     Test.test(
       "size 2^32 - 1",
@@ -2335,18 +2335,13 @@ Test.suite(
   }
 );
 
-// Operations whose argument is a SIZE (not an index) must accept the value
-// 2^32 — the size of a completely full list. Internally they pass it to
-// locate(), whose Nat32 conversion can only express indices (<= 2^32 - 1),
-// so today all three trap with "losing precision". locate(2^32) must
-// return the normalized one-past-the-end position (131_072, 0), like it
-// already does at every smaller data-block boundary (e.g. locate(8) is
-// the start of the next block).
-// The same defect makes repeat/tabulate/addRepeat trap when constructing
-// a list of size exactly 2^32; that case has no value-asserting test
-// because a successful construction needs ~32 GB of data blocks.
+// Operations whose argument is a SIZE (not an index) must accept sizes at
+// data-block boundaries, where locate() returns the normalized
+// one-past-the-end position — locate(2^32) is (131_072, 0), like locate(8)
+// is the start of the next block. These states, once the capacity
+// boundary, are ordinary interior points now and must keep working.
 Test.suite(
-  "size-valued arguments at the 2^32 capacity boundary",
+  "size-valued arguments at 2^32 (the former capacity boundary)",
   func() {
     Test.test(
       "lastIndexOf scans from the very end",
@@ -2390,6 +2385,106 @@ Test.suite(
         };
         List.addRepeat(fake, 7, 0);
         Test.expect.nat(List.size(fake)).equal(4_294_967_296)
+      }
+    )
+  }
+);
+
+// Sizes beyond the former 2^32 capacity are ordinary now. The states are
+// crafted (see the comments above); memory only permits structural tests
+// (ones that touch data blocks) up to mid-range sizes.
+Test.suite(
+  "sizes beyond the former 2^32 capacity",
+  func() {
+    Test.test(
+      "the 2^32+1-th add succeeds and all accessors agree",
+      func() {
+        let fake : List.List<Nat> = {
+          var blocks = VarArray.repeat<[var ?Nat]>([var], 131_072);
+          var blockIndex = 131_072;
+          var elementIndex = 0
+        };
+        List.add(fake, 7);
+        Test.expect.nat(List.size(fake)).equal(4_294_967_297);
+        Test.expect.nat(List.at(fake, 4_294_967_296)).equal(7);
+        Test.expect.bool(List.get(fake, 4_294_967_296) == ?7).equal(true);
+        List.put(fake, 4_294_967_296, 9);
+        Test.expect.bool(List.last(fake) == ?9).equal(true)
+      }
+    );
+    Test.test(
+      "structural operations on a faked full 2^40 list",
+      func() {
+        let fake : List.List<Nat> = {
+          var blocks = VarArray.repeat<[var ?Nat]>([var], 2_097_152);
+          var blockIndex = 2_097_152;
+          var elementIndex = 0
+        };
+        Test.expect.nat(List.size(fake)).equal(1_099_511_627_776);
+        List.add(fake, 9);
+        Test.expect.nat(List.size(fake)).equal(1_099_511_627_777);
+        Test.expect.nat(List.at(fake, 1_099_511_627_776)).equal(9);
+        Test.expect.bool(List.get(fake, 1_099_511_627_776) == ?9).equal(true);
+        ignore List.removeLast(fake);
+        Test.expect.nat(List.size(fake)).equal(1_099_511_627_776)
+      }
+    )
+  }
+);
+
+// The capacity is 2^61: the largest full-epoch capacity whose index block
+// arithmetic stays within Nat32 (index block length 3 * 2^30, data blocks
+// 1..(3 * 2^30 - 1)). A completely full list has the insertion state
+// (3 * 2^30, 0). The data blocks of the crafted states stay empty; a
+// structural test at this size is impossible (the index block alone would
+// be gigabytes), and exceeding the capacity traps, which a wasi-mode test
+// cannot assert as a passing test (verified manually: repeat of
+// 2^61 + 1 elements traps with "List capacity of 2^61 elements exceeded").
+Test.suite(
+  "the 2^61 capacity boundary",
+  func() {
+    Test.test(
+      "size 2^61 - 1",
+      func() {
+        let fake : List.List<Nat> = {
+          var blocks = [var] : [var [var ?Nat]];
+          var blockIndex = 3_221_225_471;
+          var elementIndex = 1_073_741_823
+        };
+        Test.expect.nat(List.size(fake)).equal(2_305_843_009_213_693_951)
+      }
+    );
+    Test.test(
+      "size 2^61 (completely full list)",
+      func() {
+        let fake : List.List<Nat> = {
+          var blocks = [var] : [var [var ?Nat]];
+          var blockIndex = 3_221_225_472;
+          var elementIndex = 0
+        };
+        Test.expect.nat(List.size(fake)).equal(2_305_843_009_213_693_952)
+      }
+    );
+    Test.test(
+      "truncate to the current size 2^61 is a no-op",
+      func() {
+        // also exercises newIndexBlockLength at its maximal legal input,
+        // block index 3 * 2^30 - 1, without firing the capacity guard
+        let fake : List.List<Nat> = {
+          var blocks = [var] : [var [var ?Nat]];
+          var blockIndex = 3_221_225_472;
+          var elementIndex = 0
+        };
+        List.truncate(fake, 2_305_843_009_213_693_952);
+        Test.expect.nat(List.size(fake)).equal(2_305_843_009_213_693_952)
+      }
+    );
+    Test.test(
+      "get returns null at and beyond the maximal index",
+      func() {
+        let small = List.fromArray<Nat>([1, 2, 3]);
+        Test.expect.bool(List.get(small, 2_305_843_009_213_693_951) == null).equal(true);
+        Test.expect.bool(List.get(small, 2_305_843_009_213_693_952) == null).equal(true)
       }
     )
   }


### PR DESCRIPTION
The hot-path arithmetic (locate, size, indexByBlockElement and the inlined copies in at/get/put) is already Nat64-based and handles any index below 2^64; what capped the capacity at 2^32 was only the guard. The new capacity 2^61 is the largest full-epoch capacity for which the Nat32 arithmetic of the cold-path helpers (dataBlockSize, newIndexBlockLength, shrinkIndexBlockIfNeeded, binarySearch's epoch scan) stays exact: the rounded-up index block length 3 * 2^30 is the largest representable ladder value. Keeping those helpers on Nat32 keeps the diff small; the guard in newIndexBlockLength becomes the shift test blockIndex >> 30 == 3 (top two bits set, i.e.
>= 3 * 2^30), and requests whose block index does not even fit 32 bits
trap earlier at the call sites' Nat.toNat32 conversions.

The former boundary is now interior: the 2^32+1-th add succeeds with size/at/get/put all agreeing. Tests: the old 2^32 capacity suites are repurposed as interior-point tests, a new suite covers sizes beyond 2^32 structurally (full accessor round trip on a faked 2^40 list), and a new suite pins the 2^61 boundary arithmetic (size at 2^61 - 1 and 2^61, truncate no-op at capacity driving newIndexBlockLength at its maximal legal input, get returning null beyond the maximal index). Exceeding the capacity traps with "List capacity of 2^61 elements exceeded" (verified by probe; not expressible as a passing wasi test).

Benchmarked (add/at/get/put/size, single calls): instruction counts identical to the 2^32 version in every cell, under both enhanced orthogonal persistence and legacy persistence -- the capacity raise is free on the hot paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the maximum supported list capacity on 64-bit systems from 2³² to 2⁶¹ elements.
  * Enabled list operations to work correctly with sizes and indices beyond 2³².

* **Bug Fixes**
  * Improved handling of capacity boundaries, oversized indices, truncation, repeated additions, and out-of-range lookups.
  * Expanded boundary coverage to ensure stable behavior at the maximum supported capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->